### PR TITLE
Delay setting up the audio until after the driver has been initialised

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
 #Fightcade-fbneo
-================
 Fightcade emulator built with FBNeo and GGPO
 Public Release: https://www.fightcade.com
 
-# FinalBurn Neo
-================
+#FinalBurn Neo
 Official Forum: https://neo-source.com
 
-# How to Compile
-================
+#How to Compile
 NOTE: Only the Visual Studio 2015 project is able to be compiled.
 All the others will be broken due to bad C++ include paths.
 
 1) Download, install and run Visual Studio 2019 IDE Community Edition from https://visualstudio.microsoft.com/.
 
 2) Download and install the 2010 Direct-X SDK from https://www.microsoft.com/en-gb/download/details.aspx?id=6812).
-   Make sure that you install it to the default location. The install may also error out at the end, but just ignore it.
+   Make sure that you install it to the default location. The installer may also error out at the end, but just ignore it.
 
 3) Go to 'projectfiles\visualstudio-2015' and open 'fbneo_vs2015.sln' in VS2019.
 4) Select development with C++ if you are asked.
@@ -30,7 +27,7 @@ All the others will be broken due to bad C++ include paths.
    
 8) Make the files "detector_buffers.h" and "detector_loaders.h" (just empty files) and put them in "src\intf\video\win32".
 9) Make sure the build settings are set to "Release, x86".
-10) Attempt to compile the project by pressing F6 (or by selecting 'Build' from menu).
+10) Attempt to compile the project by pressing F6 (or by selecting 'Build' and then 'Build Solution' from the menu).
 11) Install Fightcade from https://www.fightcade.com/.
 12) Copy all the DLL's from the Fightcade FBNeo path (IE: 'emulator\fbneo') to the 'build' directory where 'fcadefbneo.exe' was just compiled to.
 13) Try to run 'fcadefbneo.exe' that was compiled in the 'build' directory.

--- a/src/burner/win32/drv.cpp
+++ b/src/burner/win32/drv.cpp
@@ -180,14 +180,18 @@ int DrvInit(int nDrvNum, bool bRestore)
 		nVidFullscreen = 1;
 	}
 
-	// Init input and audio, save blitter init for later. (reduce # of mode changes, nice for emu front-ends)
-	bVidOkay = 1;
+	// Init the input and save the audio as well as the blitter init for later
+	// IE: reduce the number of mode changes which is nice for emulator front-ends
+	// this fixes the Mortal Kombat games from having the incorrect audio pitch when being launched via the command line
+	bVidOkay = 1; // don't init video yet
+	bAudOkay = 1; // don't init audio yet (but grab the soundcard params (nBurnSoundRate) so soundcores can init)
 	MediaInit();
 	bVidOkay = 0;
+	bAudOkay = 0;
 
 	// Define nMaxPlayers early; GameInpInit() needs it (normally defined in DoLibInit()).
 	nMaxPlayers = BurnDrvGetMaxPlayers();
-	GameInpInit();					// Init game input
+	GameInpInit(); // Init game input
 
 	if(ConfigGameLoad(true)) {
 		ConfigGameLoadHardwareDefaults();

--- a/src/burner/win32/main.cpp
+++ b/src/burner/win32/main.cpp
@@ -1037,10 +1037,6 @@ int ProcessCmdLine()
 		MenuEnableItems();
 	}
 
-	// audio pitch fix for Mortal Kombat games when being launched via the command line
-	MediaExit(true); // exit the sound system (see 'media.cpp')
-	MediaInit(); // initialize the sound system (see 'media.cpp')
-
 	return 0;
 }
 


### PR DESCRIPTION
Improves on the original Mortal Kombat audio pitch fix when being launched from the command line. README.md was also updated.