### PR TITLE
some changes in capcom/dataeast/md/neogeo/nes

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -23733,14 +23733,14 @@ struct BurnDriver BurnDrvCpsFfightaemgc = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-// Street Fighter II Mix (Ver 1.3)
+// Street Fighter II Mix (v1.4, Hack)
 // Hacked by ZERO800 - BRAZIL
 // For more infomation, please visit: https://sf2mix.github.io/
 
 static struct BurnRomInfo sf2mixRomDesc[] = {
-	{ "smxe_23b.8f",   0x080000, 0x478d09c6, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "smx_22b.7f",    0x080000, 0x23212fb2, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "smx_21a.6f",    0x080000, 0xd3d77d12, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "smxe_23b.8f",   0x080000, 0xc1370215, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "smx_22b.7f",    0x080000, 0x5b0566c8, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "smx_21a.6f",    0x080000, 0xcb6ab274, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
 	{ "smx-1m.3a",     0x080000, 0xa8f70643, BRF_GRA | CPS1_TILES },
 	{ "smx-3m.5a",     0x080000, 0xf73f1913, BRF_GRA | CPS1_TILES },
@@ -23774,7 +23774,7 @@ STD_ROM_FN(sf2mix)
 
 struct BurnDriver BurnDrvCpssf2mix = {
 	"sf2mix", "sf2ce", NULL, NULL, "2023",
-	"Street Fighter II Mix (v1.3)\0", NULL, "hack", "CPS1",
+	"Street Fighter II Mix (v1.4, Hack)\0", NULL, "hack (Zero800)", "CPS1",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS1, GBF_VSFIGHT, FBF_SF,
 	NULL, sf2mixRomInfo, sf2mixRomName, NULL, NULL, NULL, NULL, Sf2InputInfo, Sf2mixDIPInfo,

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -9725,7 +9725,7 @@ struct BurnDriver BurnDrvCpsCsclubjy = {
 
 struct BurnDriver BurnDrvCpsCybots = {
 	"cybots", NULL, NULL, NULL, "1995",
-	"Cyberbots - fullmetal madness (950424 Euro)\0", NULL, "Capcom", "CPS2",
+	"Cyberbots: Fullmetal Madness (950424 Euro)\0", NULL, "Capcom", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, 0,
 	NULL, CybotsRomInfo, CybotsRomName, NULL, NULL, NULL, NULL, CybotsInputInfo, NULL,
@@ -9735,7 +9735,7 @@ struct BurnDriver BurnDrvCpsCybots = {
 
 struct BurnDriver BurnDrvCpsCybotsj = {
 	"cybotsj", "cybots", NULL, NULL, "1995",
-	"Cyberbots - fullmetal madness (950420 Japan)\0", NULL, "Capcom", "CPS2",
+	"Cyberbots: Fullmetal Madness (950420 Japan)\0", NULL, "Capcom", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, 0,
 	NULL, CybotsjRomInfo, CybotsjRomName, NULL, NULL, NULL, NULL, CybotsInputInfo, NULL,
@@ -9745,7 +9745,7 @@ struct BurnDriver BurnDrvCpsCybotsj = {
 
 struct BurnDriver BurnDrvCpsCybotsu = {
 	"cybotsu", "cybots", NULL, NULL, "1995",
-	"Cyberbots - fullmetal madness (950424 USA)\0", NULL, "Capcom", "CPS2",
+	"Cyberbots: Fullmetal Madness (950424 USA)\0", NULL, "Capcom", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, 0,
 	NULL, CybotsuRomInfo, CybotsuRomName, NULL, NULL, NULL, NULL, CybotsInputInfo, NULL,
@@ -9755,7 +9755,7 @@ struct BurnDriver BurnDrvCpsCybotsu = {
 
 struct BurnDriver BurnDrvCpsCybotsam = {
 	"cybotsam", "cybots", NULL, NULL, "2022",
-	"Cyberbots - fullmetal madness Unlock Hack\0", NULL, "hack", "CPS2",
+	"Cyberbots: Fullmetal Madness (Access Mod, Hack)\0", NULL, "hack", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, 0,
 	NULL, CybotsamRomInfo, CybotsamRomName, NULL, NULL, NULL, NULL, CybotsInputInfo, NULL,
@@ -9765,10 +9765,10 @@ struct BurnDriver BurnDrvCpsCybotsam = {
 
 struct BurnDriver BurnDrvCpsCybotsbh = {
 	"cybotsbh", "cybots", NULL, NULL, "2023",
-	"Cyberbots - fullmetal madness (Boss Hack)\0", NULL, "hack", "CPS2",
+	"Cyberbots: Fullmetal Madness (Boss Hack)\0", NULL, "hack", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, 0,
-	NULL, CybotsbhRomInfo, CybotsbhRomName, NULL, NULL, NULL, NULL, Cps2FightingInputInfo, NULL,
+	NULL, CybotsbhRomInfo, CybotsbhRomName, NULL, NULL, NULL, NULL, CybotsInputInfo, NULL,
 	Cps2Init, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
@@ -13966,7 +13966,7 @@ struct BurnDriver BurnDrvCpsCsclub1d = {
 
 struct BurnDriver BurnDrvCpsCybotsud = {
 	"cybotsud", "cybots", NULL, NULL, "1995",
-	"Cyberbots - fullmetal madness (950424 USA Phoenix Edition)\0", NULL, "bootleg", "CPS2",
+	"Cyberbots: Fullmetal Madness (950424 USA Phoenix Edition)\0", NULL, "bootleg", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, 0,
 	NULL, CybotsudRomInfo, CybotsudRomName, NULL, NULL, NULL, NULL, CybotsInputInfo, NULL,
@@ -13976,7 +13976,7 @@ struct BurnDriver BurnDrvCpsCybotsud = {
 
 struct BurnDriver BurnDrvCpsCybotsjd = {
 	"cybotsjd", "cybots", NULL, NULL, "1995",
-	"Cyberbots - fullmetal madness (Japan 950424) (decrypted bootleg)\0", NULL, "bootleg", "CPS2",
+	"Cyberbots: Fullmetal Madness (Japan 950424) (decrypted bootleg)\0", NULL, "bootleg", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, 0,
 	NULL, CybotsjdRomInfo, CybotsjdRomName, NULL, NULL, NULL, NULL, CybotsInputInfo, NULL,

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -13116,15 +13116,15 @@ static struct BurnRomInfo RingdstdRomDesc[] = {
 STD_ROM_PICK(Ringdstd)
 STD_ROM_FN(Ringdstd)
 
-// Street Fighter II': Prime (Ver 0.50, Hack)
+// Street Fighter II': Prime (Ver 0.56, Hack)
 // Modified by Zero800
 // https://sf2prime.github.io/
 
 static struct BurnRomInfo Sf2primeRomDesc[] = {
-	{ "sf2pr.03",		0x080000, 0xadaea9d7, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "sf2pr.04",		0x080000, 0x75dcbaf0, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "sf2pr.05",		0x080000, 0xbd0ea568, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "sf2pr.06",		0x080000, 0xca5f7934, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.03",		0x080000, 0x4178d05d, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.04",		0x080000, 0x09e9f78b, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.05",		0x080000, 0xb020c201, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.06",		0x080000, 0x0b960430, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
 #if 0
 	// All filled with 0xFF.
 	{ "sf2pr.07",		0x080000, 0x504bf849, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
@@ -13133,10 +13133,10 @@ static struct BurnRomInfo Sf2primeRomDesc[] = {
 	{ "sf2pr.10",		0x080000, 0x504bf849, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
 #endif
 
-	{ "sf2pr.13m",		0x800000, 0xf48a99a4, CPS2_GFX | BRF_GRA },
-	{ "sf2pr.15m",		0x800000, 0xabf5f4b2, CPS2_GFX | BRF_GRA },
-	{ "sf2pr.17m",		0x800000, 0x87dd1b40, CPS2_GFX | BRF_GRA },
-	{ "sf2pr.19m",		0x800000, 0xb3395339, CPS2_GFX | BRF_GRA },
+	{ "sf2pr.13m",		0x800000, 0xfb796487, CPS2_GFX | BRF_GRA },
+	{ "sf2pr.15m",		0x800000, 0xf5419f30, CPS2_GFX | BRF_GRA },
+	{ "sf2pr.17m",		0x800000, 0x8266131f, CPS2_GFX | BRF_GRA },
+	{ "sf2pr.19m",		0x800000, 0xd6cc4ba6, CPS2_GFX | BRF_GRA },
 
 	{ "sf2pr.01",		0x020000, 0x6ce233a7, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
 	{ "sf2pr.02",		0x020000, 0x2d8794aa, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
@@ -14284,7 +14284,7 @@ struct BurnDriver BurnDrvCpsRingdstd = {
 
 struct BurnDriver BurnDrvCpsSf2prime = {
 	"sf2prime", "hsf2", NULL, NULL, "2025",
-	"Street Fighter II': Prime (Ver 0.50, Hack)\0", NULL, "hack (Zero800)", "CPS2",
+	"Street Fighter II': Prime (Ver 0.56, Hack)\0", NULL, "hack (Zero800)", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, FBF_SF,
 	NULL, Sf2primeRomInfo, Sf2primeRomName, NULL, NULL, NULL, NULL, Cps2FightingInputInfo, NULL,

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -3037,31 +3037,31 @@ STD_ROM_PICK(Vampjr1)
 STD_ROM_FN(Vampjr1)
 
 static struct BurnRomInfo VampjbhRomDesc[] = {
-	{ "vamjbh.03",        0x080000, 0x55c1be82, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "vamjbh.04",        0x080000, 0x9c12017e, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "vamj.05a",         0x080000, 0x6c497e92, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "vamj.06a",         0x080000, 0xf1bbecb6, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "vamj.07a",         0x080000, 0x1067ad84, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "vamj.08a",         0x080000, 0x4b89f41f, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "vamj.09a",         0x080000, 0xfc0a4aac, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
-	{ "vamj.10a",         0x080000, 0x9270c26b, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamjbh.03a",		0x080000, 0x55c1be82, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamjbh.04b",		0x080000, 0x9c12017e, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamj.05a",		0x080000, 0x6c497e92, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamj.06a",		0x080000, 0xf1bbecb6, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamj.07a",		0x080000, 0x1067ad84, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamj.08a",		0x080000, 0x4b89f41f, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamj.09a",		0x080000, 0xfc0a4aac, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "vamj.10a",		0x080000, 0x9270c26b, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
 
-	{ "vam.13m",          0x400000, 0xc51baf99, CPS2_GFX | BRF_GRA },
-	{ "vam.15m",          0x400000, 0x3ce83c77, CPS2_GFX | BRF_GRA },
-	{ "vam.17m",          0x400000, 0x4f2408e0, CPS2_GFX | BRF_GRA },
-	{ "vam.19m",          0x400000, 0x9ff60250, CPS2_GFX | BRF_GRA },
-	{ "vam.14m",          0x100000, 0xbd87243c, CPS2_GFX | BRF_GRA },
-	{ "vam.16m",          0x100000, 0xafec855f, CPS2_GFX | BRF_GRA },
-	{ "vam.18m",          0x100000, 0x3a033625, CPS2_GFX | BRF_GRA },
-	{ "vam.20m",          0x100000, 0x2bff6a89, CPS2_GFX | BRF_GRA },
+	{ "vam.13m",		0x400000, 0xc51baf99, CPS2_GFX | BRF_GRA },
+	{ "vam.15m",		0x400000, 0x3ce83c77, CPS2_GFX | BRF_GRA },
+	{ "vam.17m",		0x400000, 0x4f2408e0, CPS2_GFX | BRF_GRA },
+	{ "vam.19m",		0x400000, 0x9ff60250, CPS2_GFX | BRF_GRA },
+	{ "vam.14m",		0x100000, 0xbd87243c, CPS2_GFX | BRF_GRA },
+	{ "vam.16m",		0x100000, 0xafec855f, CPS2_GFX | BRF_GRA },
+	{ "vam.18m",		0x100000, 0x3a033625, CPS2_GFX | BRF_GRA },
+	{ "vam.20m",		0x100000, 0x2bff6a89, CPS2_GFX | BRF_GRA },
 
-	{ "vam.01",           0x020000, 0x64b685d5, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
-	{ "vam.02",           0x020000, 0xcf7c97c7, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+	{ "vam.01",			0x020000, 0x64b685d5, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+	{ "vam.02",			0x020000, 0xcf7c97c7, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
 
-	{ "vam.11m",         0x200000, 0x4a39deb2, CPS2_QSND | BRF_SND },
-	{ "vam.12m",         0x200000, 0x1a3e5c03, CPS2_QSND | BRF_SND },
+	{ "vam.11m",		0x200000, 0x4a39deb2, CPS2_QSND | BRF_SND },
+	{ "vam.12m",		0x200000, 0x1a3e5c03, CPS2_QSND | BRF_SND },
 
-	{ "vampj.key",       0x000014, 0x8418cc6f, CPS2_ENCRYPTION_KEY },
+	{ "vampj.key",		0x000014, 0x8418cc6f, CPS2_ENCRYPTION_KEY },
 };
 
 STD_ROM_PICK(Vampjbh)
@@ -4426,6 +4426,41 @@ static struct BurnRomInfo Mshvsfu1RomDesc[] = {
 
 STD_ROM_PICK(Mshvsfu1)
 STD_ROM_FN(Mshvsfu1)
+
+// Marvel Super Heroes Vs. Street Fighter (Coop, Hack)
+// Modified by bankbank
+// 20240628
+
+static struct BurnRomInfo MshvsfcphRomDesc[] = {
+	{ "mvsecph.03f",	0x080000, 0x086f345a, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "mvse.04f",		0x080000, 0x6ef799f9, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "mvs.05a",		0x080000, 0x1a5de0cb, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "mvs.06a",		0x080000, 0x959f3030, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "mvs.07b",		0x080000, 0x7f915bdb, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "mvs.08a",		0x080000, 0xc2813884, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "mvs.09b",		0x080000, 0x3ba08818, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "mvs.10b",		0x080000, 0xcf0dba98, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+
+	{ "mvs.13m",		0x400000, 0x29b05fd9, CPS2_GFX | BRF_GRA },
+	{ "mvs.15m",		0x400000, 0xfaddccf1, CPS2_GFX | BRF_GRA },
+	{ "mvs.17m",		0x400000, 0x97aaf4c7, CPS2_GFX | BRF_GRA },
+	{ "mvs.19m",		0x400000, 0xcb70e915, CPS2_GFX | BRF_GRA },
+	{ "mvs.14m",		0x400000, 0xb3b1972d, CPS2_GFX | BRF_GRA },
+	{ "mvs.16m",		0x400000, 0x08aadb5d, CPS2_GFX | BRF_GRA },
+	{ "mvs.18m",		0x400000, 0xc1228b35, CPS2_GFX | BRF_GRA },
+	{ "mvs.20m",		0x400000, 0x366cc6c2, CPS2_GFX | BRF_GRA },
+
+	{ "mvs.01",			0x020000, 0x68252324, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+	{ "mvs.02",			0x020000, 0xb34e773d, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+
+	{ "mvs.11m",		0x400000, 0x86219770, CPS2_QSND | BRF_SND },
+	{ "mvs.12m",		0x400000, 0xf2fd7f68, CPS2_QSND | BRF_SND },
+	
+	{ "mshvsf.key",		0x000014, 0x64660867, CPS2_ENCRYPTION_KEY },
+};
+
+STD_ROM_PICK(Mshvsfcph)
+STD_ROM_FN(Mshvsfcph)
 
 static struct BurnRomInfo MsvsfbhRomDesc[] = {
 	{ "mvsbh.03i",      0x080000, 0x54ecd389, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
@@ -10633,6 +10668,16 @@ struct BurnDriver BurnDrvCpsMshvsfu1 = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvCpsMshvsfcph = {
+	"mshvsfcph", "mshvsf", NULL, NULL, "2024",
+	"Marvel Super Heroes Vs. Street Fighter (Coop, Hack)\0", NULL, "hack (bankbank)", "CPS2",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, FBF_SF,
+	NULL, MshvsfcphRomInfo, MshvsfcphRomName, NULL, NULL, NULL, NULL, Cps2FightingInputInfo, NULL,
+	Cps2Init, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvCpsMsvsfbh = {
 	"msvsfbh", "mshvsf", NULL, NULL, "1997",
 	"Marvel Super Heroes vs Street Fighter (Boss Hack)\0", NULL, "hack", "CPS2",
@@ -13071,6 +13116,39 @@ static struct BurnRomInfo RingdstdRomDesc[] = {
 STD_ROM_PICK(Ringdstd)
 STD_ROM_FN(Ringdstd)
 
+// Street Fighter II': Prime (Ver 0.50, Hack)
+// Modified by Zero800
+// https://sf2prime.github.io/
+
+static struct BurnRomInfo Sf2primeRomDesc[] = {
+	{ "sf2pr.03",		0x080000, 0xadaea9d7, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.04",		0x080000, 0x75dcbaf0, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.05",		0x080000, 0xbd0ea568, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.06",		0x080000, 0xca5f7934, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+#if 0
+	// All filled with 0xFF.
+	{ "sf2pr.07",		0x080000, 0x504bf849, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.08",		0x080000, 0x504bf849, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.09",		0x080000, 0x504bf849, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sf2pr.10",		0x080000, 0x504bf849, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+#endif
+
+	{ "sf2pr.13m",		0x800000, 0xf48a99a4, CPS2_GFX | BRF_GRA },
+	{ "sf2pr.15m",		0x800000, 0xabf5f4b2, CPS2_GFX | BRF_GRA },
+	{ "sf2pr.17m",		0x800000, 0x87dd1b40, CPS2_GFX | BRF_GRA },
+	{ "sf2pr.19m",		0x800000, 0xb3395339, CPS2_GFX | BRF_GRA },
+
+	{ "sf2pr.01",		0x020000, 0x6ce233a7, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+	{ "sf2pr.02",		0x020000, 0x2d8794aa, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+
+	{ "sf2pr.11m",		0x800000, 0xcd8b2d9f, CPS2_QSND | BRF_SND },
+
+	{ "phoenix.key",	0x000014, 0x2cf772b0, CPS2_ENCRYPTION_KEY },
+};
+
+STD_ROM_PICK(Sf2prime)
+STD_ROM_FN(Sf2prime)
+
 static struct BurnRomInfo SfadRomDesc[] = {
 	{ "sfzed.03d",     0x080000, 0xa1a54827, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
 	{ "sfz.04b",       0x080000, 0x8b73b0e5, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
@@ -14204,6 +14282,16 @@ struct BurnDriver BurnDrvCpsRingdstd = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvCpsSf2prime = {
+	"sf2prime", "hsf2", NULL, NULL, "2025",
+	"Street Fighter II': Prime (Ver 0.50, Hack)\0", NULL, "hack (Zero800)", "CPS2",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, FBF_SF,
+	NULL, Sf2primeRomInfo, Sf2primeRomName, NULL, NULL, NULL, NULL, Cps2FightingInputInfo, NULL,
+	Ssf2tPhoenixInit, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvCpsSfad = {
 	"sfad", "sfa", NULL, NULL, "1995",
 	"Street Fighter Alpha - warriors' dreams (950727 Euro Phoenix Edition)\0", NULL, "bootleg", "CPS2",
@@ -14316,7 +14404,7 @@ struct BurnDriver BurnDrvCpsSfz3jr2d = {
 
 struct BurnDriver BurnDrvCpsSfz3mix13 = {
 	"sfz3mix13", "sfa3", NULL, NULL, "2022",
-	"Street Fighter Zero 3 Mix (v0.13)\0", NULL, "hack", "CPS2",
+	"Street Fighter Zero 3 Mix (v0.13, Hack)\0", NULL, "hack (Zero800)", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, FBF_SF,
 	NULL, Sfz3mix13RomInfo, Sfz3mix13RomName, NULL, NULL, NULL, NULL, Cps2FightingInputInfo, NULL,

--- a/src/burn/drv/cps3/d_cps3.cpp
+++ b/src/burn/drv/cps3/d_cps3.cpp
@@ -281,6 +281,7 @@ static struct BurnDIPInfo japanwarzardDIPList[] = {
 	{0x1B,	0xFF, 0xFF,	0x51, NULL},
 };
 
+STDDIPINFOEXT(hispanic, region, hispanicRegion)
 STDDIPINFOEXT(japan, region, japanRegion)
 STDDIPINFOEXT(asia, region, asiaRegion)
 STDDIPINFOEXT(euro, region, euroRegion)
@@ -324,9 +325,9 @@ STDDIPINFOEXT(sfiiieuro, sfiii, euroRegion)
 	{ "sfiii-simm5.0",			0x200000, 0x9bc108b2, BRF_GRA }, \
 	{ "sfiii-simm5.1",			0x200000, 0xc6f1c066, BRF_GRA },
 
-// -----------------------------------------------
-// Street Fighter III: New Generation (Euro 970204)
-// -----------------------------------------------
+// --------------------------------------------------
+// Street Fighter III: New Generation (Europe 970204)
+// --------------------------------------------------
 static struct BurnRomInfo sfiiiRomDesc[] = {
 
 	{ "sfiii_euro.29f400.u2",				0x080000, 0x27699ddc, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -493,6 +494,21 @@ static struct BurnRomInfo sfiii2jRomDesc[] = {
 STD_ROM_PICK(sfiii2j)
 STD_ROM_FN(sfiii2j)
 
+// ----------------------------------------------------------
+// Street Fighter III 2nd Impact: Giant Attack (Hispanic 970930)
+// ----------------------------------------------------------
+static struct BurnRomInfo sfiii2hRomDesc[] = {
+
+	{ "sfiii2_hispanic.29f400.u2",			0x080000, 0x5c799526, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+#if !defined ROM_VERIFY
+	SFIII2_970930_FLASH
+#endif
+};
+
+STD_ROM_PICK(sfiii2h)
+STD_ROM_FN(sfiii2h)
+
 // ----------------------------------------------------------------
 // Street Fighter III 2nd Impact: Giant Attack (Asia 970930, NO CD)
 // ----------------------------------------------------------------
@@ -552,9 +568,9 @@ STD_ROM_FN(sfiii2n)
 	{ "sfiii3-simm6.6",			0x200000, 0x450e8d28, BRF_GRA }, \
 	{ "sfiii3-simm6.7",			0x200000, 0xcc5f4187, BRF_GRA },
 
-// -----------------------------------------------------------------
-// Street Fighter III 3rd Strike: Fight for the Future (Euro 990608)
-// -----------------------------------------------------------------
+// -------------------------------------------------------------------
+// Street Fighter III 3rd Strike: Fight for the Future (Europe 990608)
+// -------------------------------------------------------------------
 static struct BurnRomInfo sfiii3RomDesc[] = {
 
 	{ "sfiii3_euro.29f400.u2",				0x080000, 0x30bbf293, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -610,6 +626,19 @@ static struct BurnRomInfo sfiii3nRomDesc[] = {
 STD_ROM_PICK(sfiii3n)
 STD_ROM_FN(sfiii3n)
 
+// -------------------------------------------------------------------------
+// Street Fighter III 3rd Strike: Fight for the Future (Asia 990608, NO CD)
+// -------------------------------------------------------------------------
+static struct BurnRomInfo sfiii3naRomDesc[] = {
+
+	{ "sfiii3_asia_nocd.29f400.u2",		0x080000, 0xa12ebcd1, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+	SFIII3_990608_FLASH
+};
+
+STD_ROM_PICK(sfiii3na)
+STD_ROM_FN(sfiii3na)
+
 // ------------------------------------------------------------
 // Street Fighter III 3rd Strike: Fight for the Future (990512)
 // ------------------------------------------------------------
@@ -656,9 +685,9 @@ STD_ROM_FN(sfiii3n)
 	{ "sfiii3-simm6.6",			0x200000, 0x450e8d28, BRF_GRA }, \
 	{ "sfiii3-simm6.7",			0x200000, 0xcc5f4187, BRF_GRA },
 
-// -----------------------------------------------------------------
-// Street Fighter III 3rd Strike: Fight for the Future (Euro 990512)
-// -----------------------------------------------------------------
+// -------------------------------------------------------------------
+// Street Fighter III 3rd Strike: Fight for the Future (Europe 990512)
+// -------------------------------------------------------------------
 static struct BurnRomInfo sfiii3r1RomDesc[] = {
 
 	{ "sfiii3_euro.29f400.u2",				0x080000, 0x30bbf293, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -714,6 +743,19 @@ static struct BurnRomInfo sfiii3nr1RomDesc[] = {
 STD_ROM_PICK(sfiii3nr1)
 STD_ROM_FN(sfiii3nr1)
 
+// -------------------------------------------------------------------------
+// Street Fighter III 3rd Strike: Fight for the Future (Asia 990512, NO CD)
+// -------------------------------------------------------------------------
+static struct BurnRomInfo sfiii3nar1RomDesc[] = {
+
+	{ "sfiii3_asia_nocd.29f400.u2",		0x080000, 0xa12ebcd1, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+	SFIII3_990512_FLASH
+};
+
+STD_ROM_PICK(sfiii3nar1)
+STD_ROM_FN(sfiii3nar1)
+
 // -------------------------------------------------
 // JoJo no Kimyou na Bouken / JoJo's Venture (990128)
 // -------------------------------------------------
@@ -746,9 +788,9 @@ STD_ROM_FN(sfiii3nr1)
 	{ "jojo-simm5.0",			0x200000, 0x797615fc, BRF_GRA }, \
 	{ "jojo-simm5.1",			0x200000, 0x734fd162, BRF_GRA },
 	
-// -----------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (Euro 990128)
-// -----------------------------------------------------
+// ------------------------------
+// JoJo's Venture (Europe 990128)
+// ------------------------------
 static struct BurnRomInfo jojoRomDesc[] = {
 
 	{ "jojo_euro.29f400.u2",				0x080000, 0x513e40ec, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -761,9 +803,9 @@ static struct BurnRomInfo jojoRomDesc[] = {
 STD_ROM_PICK(jojo)
 STD_ROM_FN(jojo)
 
-// -------------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (USA 990128)
-// -------------------------------------------------------
+// ---------------------------
+// JoJo's Venture (USA 990128)
+// ---------------------------
 static struct BurnRomInfo jojouRomDesc[] = {
 
 	{ "jojo_usa.29f400.u2",					0x080000, 0x8d40f7be, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -776,9 +818,24 @@ static struct BurnRomInfo jojouRomDesc[] = {
 STD_ROM_PICK(jojou)
 STD_ROM_FN(jojou)
 
-// -------------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (Japan 990128)
-// -------------------------------------------------------
+// ----------------------------
+// JoJo's Venture (Asia 990128)
+// ----------------------------
+static struct BurnRomInfo jojoaRomDesc[] = {
+
+	{ "jojo_asia.29f400.u2",				0x080000, 0x789aa72a, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+#if !defined ROM_VERIFY
+	JOJO_990128_FLASH
+#endif
+};
+
+STD_ROM_PICK(jojoa)
+STD_ROM_FN(jojoa)
+
+// ---------------------------------------
+// JoJo no Kimyou na Bouken (Japan 990128)
+// ---------------------------------------
 static struct BurnRomInfo jojojRomDesc[] = {
 
 	{ "jojo_japan.29f400.u2",				0x080000, 0x02778f60, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -791,9 +848,9 @@ static struct BurnRomInfo jojojRomDesc[] = {
 STD_ROM_PICK(jojoj)
 STD_ROM_FN(jojoj)
 
-// -------------------------------------------------------------
-// JoJo's Venture / JoJo no Kimyou na Bouken (Asia 990128, NO CD)
-// -------------------------------------------------------------
+// -----------------------------------
+// JoJo's Venture (Asia 990128, NO CD)
+// -----------------------------------
 static struct BurnRomInfo jojonRomDesc[] = {
 
 	{ "jojo_asia_nocd.29f400.u2",			0x080000, 0x05b4f953, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -804,9 +861,9 @@ static struct BurnRomInfo jojonRomDesc[] = {
 STD_ROM_PICK(jojon)
 STD_ROM_FN(jojon)	
 
-// -------------------------------------------------
+// --------------------------------------------------
 // JoJo no Kimyou na Bouken / JoJo's Venture (990108)
-// -------------------------------------------------
+// --------------------------------------------------
 
 #define JOJO_990108_FLASH \
 	{ "jojo-simm1.0",			0x200000, 0xcfbc38d6, BRF_ESS | BRF_PRG }, \
@@ -836,9 +893,9 @@ STD_ROM_FN(jojon)
 	{ "jojo-simm5.0",			0x200000, 0x797615fc, BRF_GRA }, \
 	{ "jojo-simm5.1",			0x200000, 0x734fd162, BRF_GRA },
 
-// -----------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (Euro 990108)
-// -----------------------------------------------------
+// ------------------------------
+// JoJo's Venture (Europe 990108)
+// ------------------------------
 static struct BurnRomInfo jojor1RomDesc[] = {
 
 	{ "jojo_euro.29f400.u2",				0x080000, 0x513e40ec, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -851,9 +908,9 @@ static struct BurnRomInfo jojor1RomDesc[] = {
 STD_ROM_PICK(jojor1)
 STD_ROM_FN(jojor1)
 
-// -----------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (USA 990108)
-// -----------------------------------------------------
+// ---------------------------
+// JoJo's Venture (USA 990108)
+// ---------------------------
 static struct BurnRomInfo jojour1RomDesc[] = {
 
 	{ "jojo_usa.29f400.u2",					0x080000, 0x8d40f7be, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -866,9 +923,24 @@ static struct BurnRomInfo jojour1RomDesc[] = {
 STD_ROM_PICK(jojour1)
 STD_ROM_FN(jojour1)
 
-// -------------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (Japan 990108)
-// -------------------------------------------------------
+// ----------------------------
+// JoJo's Venture (Asia 990108)
+// ----------------------------
+static struct BurnRomInfo jojoar1RomDesc[] = {
+
+	{ "jojo_asia.29f400.u2",				0x080000, 0x789aa72a, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+#if !defined ROM_VERIFY
+	JOJO_990108_FLASH
+#endif
+};
+
+STD_ROM_PICK(jojoar1)
+STD_ROM_FN(jojoar1)
+
+// ---------------------------------------
+// JoJo no Kimyou na Bouken (Japan 990108)
+// ---------------------------------------
 static struct BurnRomInfo jojojr1RomDesc[] = {
 
 	{ "jojo_japan.29f400.u2",				0x080000, 0x02778f60, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -881,9 +953,9 @@ static struct BurnRomInfo jojojr1RomDesc[] = {
 STD_ROM_PICK(jojojr1)
 STD_ROM_FN(jojojr1)
 
-// -------------------------------------------------------------
-// JoJo's Venture / JoJo no Kimyou na Bouken (Asia 990108, NO CD)
-// -------------------------------------------------------------
+// -----------------------------------
+// JoJo's Venture (Asia 990108, NO CD)
+// -----------------------------------
 static struct BurnRomInfo jojonr1RomDesc[] = {
 
 	{ "jojo_asia_nocd.29f400.u2",			0x080000, 0x05b4f953, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -894,9 +966,9 @@ static struct BurnRomInfo jojonr1RomDesc[] = {
 STD_ROM_PICK(jojonr1)
 STD_ROM_FN(jojonr1)
 
-// -------------------------------------------------
+// --------------------------------------------------
 // JoJo no Kimyou na Bouken / JoJo's Venture (981202)
-// -------------------------------------------------
+// --------------------------------------------------
 
 #define JOJO_981202_FLASH \
 	{ "jojo-simm1.0",			0x200000, 0xe06ba886, BRF_ESS | BRF_PRG }, \
@@ -926,9 +998,9 @@ STD_ROM_FN(jojonr1)
 	{ "jojo-simm5.0",			0x200000, 0x797615fc, BRF_GRA }, \
 	{ "jojo-simm5.1",			0x200000, 0x734fd162, BRF_GRA },
 
-// -----------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (Euro 981202)
-// -----------------------------------------------------
+// ------------------------------
+// JoJo's Venture (Europe 981202)
+// ------------------------------
 static struct BurnRomInfo jojor2RomDesc[] = {
 
 	{ "jojo_euro.29f400.u2",				0x080000, 0x513e40ec, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -941,9 +1013,9 @@ static struct BurnRomInfo jojor2RomDesc[] = {
 STD_ROM_PICK(jojor2)
 STD_ROM_FN(jojor2)
 
-// -----------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (USA 981202)
-// -----------------------------------------------------
+// ---------------------------
+// JoJo's Venture (USA 981202)
+// ---------------------------
 static struct BurnRomInfo jojour2RomDesc[] = {
 
 	{ "jojo_usa.29f400.u2",					0x080000, 0x8d40f7be, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -956,9 +1028,24 @@ static struct BurnRomInfo jojour2RomDesc[] = {
 STD_ROM_PICK(jojour2)
 STD_ROM_FN(jojour2)
 
-// -------------------------------------------------------
-// JoJo no Kimyou na Bouken / JoJo's Venture (Japan 981202)
-// -------------------------------------------------------
+// ----------------------------
+// JoJo's Venture (Asia 981202)
+// ----------------------------
+static struct BurnRomInfo jojoar2RomDesc[] = {
+
+	{ "jojo_asia.29f400.u2",				0x080000, 0x789aa72a, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+#if !defined ROM_VERIFY
+	JOJO_981202_FLASH
+#endif
+};
+
+STD_ROM_PICK(jojoar2)
+STD_ROM_FN(jojoar2)
+
+// ---------------------------------------
+// JoJo no Kimyou na Bouken (Japan 981202)
+// ---------------------------------------
 static struct BurnRomInfo jojojr2RomDesc[] = {
 
 	{ "jojo_japan.29f400.u2",				0x080000, 0x02778f60, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -971,9 +1058,9 @@ static struct BurnRomInfo jojojr2RomDesc[] = {
 STD_ROM_PICK(jojojr2)
 STD_ROM_FN(jojojr2)
 
-// -------------------------------------------------------------
-// JoJo's Venture / JoJo no Kimyou na Bouken (Asia 981202, NO CD)
-// -------------------------------------------------------------
+// -----------------------------------
+// JoJo's Venture (Asia 981202, NO CD)
+// -----------------------------------
 static struct BurnRomInfo jojonr2RomDesc[] = {
 
 	{ "jojo_asia_nocd.29f400.u2",			0x080000, 0x05b4f953, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1022,12 +1109,12 @@ STD_ROM_FN(jojonr2)
 	{ "jojoba-simm5.6",			0x200000, 0x4fb32906, BRF_GRA }, \
 	{ "jojoba-simm5.7",			0x200000, 0x8c8be520, BRF_GRA },
 
-// ---------------------------------------------------------------------------------
-// JoJo no Kimyou na Bouken: Mirai e no Isan / JoJo's Bizarre Adventure (Japan 990927)
-// ---------------------------------------------------------------------------------
+// ----------------------------------------
+// JoJo's Bizarre Adventure (Europe 990927)
+// ----------------------------------------
 static struct BurnRomInfo jojobaRomDesc[] = {
 
-	{ "jojoba_japan.29f400.u2",				0x080000, 0x3085478c, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	{ "jojoba_euro.29f400.u2",				0x080000, 0x63cc8800, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 					  
 #if !defined ROM_VERIFY
 	JOJOBA_990927_FLASH
@@ -1037,9 +1124,24 @@ static struct BurnRomInfo jojobaRomDesc[] = {
 STD_ROM_PICK(jojoba)
 STD_ROM_FN(jojoba)
 
-// ----------------------------------------------------------------------------------------
-// JoJo no Kimyou na Bouken: Mirai e no Isan / JoJo's Bizarre Adventure (Japan 990927, NO CD)
-// ----------------------------------------------------------------------------------------
+// --------------------------------------------------------
+// JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990927)
+// --------------------------------------------------------
+static struct BurnRomInfo jojobajRomDesc[] = {
+
+	{ "jojoba_japan.29f400.u2",				0x080000, 0x3085478c, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+					  
+#if !defined ROM_VERIFY
+	JOJOBA_990927_FLASH
+#endif
+};
+
+STD_ROM_PICK(jojobaj)
+STD_ROM_FN(jojobaj)
+
+// ---------------------------------------------------------------
+// JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990927, NO CD)
+// ---------------------------------------------------------------
 static struct BurnRomInfo jojobanRomDesc[] = {
 
 	{ "jojoba_japan_nocd.29f400.u2",		0x080000, 0x4dab19f5, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1050,9 +1152,9 @@ static struct BurnRomInfo jojobanRomDesc[] = {
 STD_ROM_PICK(jojoban)
 STD_ROM_FN(jojoban)
 
-// ---------------------------------------------------------------------------------------
-// JoJo's Bizarre Adventure / JoJo no Kimyou na Bouken: Mirai e no Isan (Euro 990927, NO CD)
-// ---------------------------------------------------------------------------------------
+// -----------------------------------------------
+// JoJo's Bizarre Adventure (Europe 990927, NO CD)
+// -----------------------------------------------
 static struct BurnRomInfo jojobaneRomDesc[] = {
 
 	{ "jojoba_euro_nocd.29f400.u2",			0x080000, 0x1ee2d679, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1101,12 +1203,12 @@ STD_ROM_FN(jojobane)
 	{ "jojoba-simm5.6",			0x200000, 0x4fb32906, BRF_GRA }, \
 	{ "jojoba-simm5.7",			0x200000, 0x8c8be520, BRF_GRA },
 
-// ---------------------------------------------------------------------------------
-// JoJo no Kimyou na Bouken: Mirai e no Isan / JoJo's Bizarre Adventure (Japan 990913)
-// ---------------------------------------------------------------------------------
+// ----------------------------------------
+// JoJo's Bizarre Adventure (Europe 990913)
+// ----------------------------------------
 static struct BurnRomInfo jojobar1RomDesc[] = {
 
-	{ "jojoba_japan.29f400.u2",				0x080000, 0x3085478c, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	{ "jojoba_euro.29f400.u2",				0x080000, 0x63cc8800, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 					  
 #if !defined ROM_VERIFY
 	JOJOBA_990913_FLASH
@@ -1116,9 +1218,24 @@ static struct BurnRomInfo jojobar1RomDesc[] = {
 STD_ROM_PICK(jojobar1)
 STD_ROM_FN(jojobar1)
 
-// ----------------------------------------------------------------------------------------
-// JoJo no Kimyou na Bouken: Mirai e no Isan / JoJo's Bizarre Adventure (Japan 990913, NO CD)
-// ----------------------------------------------------------------------------------------
+// --------------------------------------------------------
+// JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990913)
+// --------------------------------------------------------
+static struct BurnRomInfo jojobajr1RomDesc[] = {
+
+	{ "jojoba_japan.29f400.u2",				0x080000, 0x3085478c, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+					  
+#if !defined ROM_VERIFY
+	JOJOBA_990913_FLASH
+#endif
+};
+
+STD_ROM_PICK(jojobajr1)
+STD_ROM_FN(jojobajr1)
+
+// ---------------------------------------------------------------
+// JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990913, NO CD)
+// ---------------------------------------------------------------
 static struct BurnRomInfo jojobanr1RomDesc[] = {
 
 	{ "jojoba_japan_nocd.29f400.u2",		0x080000, 0x4dab19f5, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1129,9 +1246,9 @@ static struct BurnRomInfo jojobanr1RomDesc[] = {
 STD_ROM_PICK(jojobanr1)
 STD_ROM_FN(jojobanr1)
 
-// ---------------------------------------------------------------------------------------
-// JoJo's Bizarre Adventure / JoJo no Kimyou na Bouken: Mirai e no Isan (Euro 990913, NO CD)
-// ---------------------------------------------------------------------------------------
+// -----------------------------------------------
+// JoJo's Bizarre Adventure (Europe 990913, NO CD)
+// -----------------------------------------------
 static struct BurnRomInfo jojobaner1RomDesc[] = {
 
 	{ "jojoba_euro_nocd.29f400.u2",			0x080000, 0x1ee2d679, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1170,9 +1287,9 @@ STD_ROM_FN(jojobaner1)
 	{ "redearth-simm5.0",		0x200000, 0x424451b9, BRF_GRA }, \
 	{ "redearth-simm5.1",		0x200000, 0x9b8cb56b, BRF_GRA },
 
-// ----------------------------------
-// Red Earth / War-Zard (Euro 961121)
-// ----------------------------------
+// -------------------------
+// Red Earth (Europe 961121)
+// -------------------------
 static struct BurnRomInfo redearthRomDesc[] = {
 
 	{ "redearth_euro.29f400.u2",			0x080000, 0x02e0f336, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1185,9 +1302,9 @@ static struct BurnRomInfo redearthRomDesc[] = {
 STD_ROM_PICK(redearth)
 STD_ROM_FN(redearth)
 
-// -----------------------------------
-// War-Zard / Red Earth (Japan 961121)
-// -----------------------------------
+// ----------------------
+// Warzard (Japan 961121)
+// ----------------------
 static struct BurnRomInfo warzardRomDesc[] = {
 
 	{ "warzard_japan.29f400.u2",			0x080000, 0xf8e2f0c6, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1200,9 +1317,22 @@ static struct BurnRomInfo warzardRomDesc[] = {
 STD_ROM_PICK(warzard)
 STD_ROM_FN(warzard)
 
-// -----------------------------
-// Red Earth / War-Zard (961023)
-// -----------------------------
+// ------------------------------
+// Red Earth (Asia 961121, NO CD)
+// ------------------------------
+static struct BurnRomInfo redearthnRomDesc[] = {
+
+	{ "redearth_asia_nocd.29f400.u2",		0x080000, 0x7a4f0851, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+	REDEARTH_961121_FLASH
+};
+
+STD_ROM_PICK(redearthn)
+STD_ROM_FN(redearthn)
+
+// ----------------------------
+// Red Earth / Warzard (961023)
+// ----------------------------
 
 #define REDEARTH_961023_FLASH \
 	{ "redearth-simm1.0",		0x200000, 0x65bac346, BRF_ESS | BRF_PRG }, \
@@ -1228,9 +1358,9 @@ STD_ROM_FN(warzard)
 	{ "redearth-simm5.0",		0x200000, 0x424451b9, BRF_GRA }, \
 	{ "redearth-simm5.1",		0x200000, 0x9b8cb56b, BRF_GRA },
 
-// ----------------------------------
-// Red Earth / War-Zard (Euro 961023)
-// ----------------------------------
+// -------------------------
+// Red Earth (Europe 961023)
+// -------------------------
 static struct BurnRomInfo redearthr1RomDesc[] = {
 
 	{ "redearth_euro.29f400.u2",			0x080000, 0x02e0f336, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1243,9 +1373,9 @@ static struct BurnRomInfo redearthr1RomDesc[] = {
 STD_ROM_PICK(redearthr1)
 STD_ROM_FN(redearthr1)
 
-// -----------------------------------
-// War-Zard / Red Earth (Japan 961023)
-// -----------------------------------
+// ----------------------
+// Warzard (Japan 961023)
+// ----------------------
 static struct BurnRomInfo warzardr1RomDesc[] = {
 
 	{ "warzard_japan.29f400.u2",		 	0x080000, 0xf8e2f0c6, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -1257,6 +1387,40 @@ static struct BurnRomInfo warzardr1RomDesc[] = {
 
 STD_ROM_PICK(warzardr1)
 STD_ROM_FN(warzardr1)
+
+// ------------------------------
+// Red Earth (Asia 961023, NO CD)
+// ------------------------------
+static struct BurnRomInfo redearthnr1RomDesc[] = {
+
+	{ "redearth_asia_nocd.29f400.u2",	0x080000, 0x7a4f0851, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	
+	{ "redearthr1-simm1.0",				0x200000, 0x65bac346, BRF_ESS | BRF_PRG },
+	{ "redearthr1-simm1.1",				0x200000, 0xa8ec4aae, BRF_ESS | BRF_PRG },
+	{ "redearthr1-simm1.2",				0x200000, 0x2caf8995, BRF_ESS | BRF_PRG },
+	{ "redearthr1-simm1.3",				0x200000, 0x13ebc21d, BRF_ESS | BRF_PRG },
+	{ "redearth-simm3.0",				0x200000, 0x83350cc5, BRF_GRA },
+	{ "redearth-simm3.1",				0x200000, 0x56734de6, BRF_GRA },
+	{ "redearth-simm3.2",				0x200000, 0x800ea0f1, BRF_GRA },
+	{ "redearth-simm3.3",				0x200000, 0x97e9146c, BRF_GRA },
+	{ "redearth-simm3.4",				0x200000, 0x0cb1d648, BRF_GRA },
+	{ "redearth-simm3.5",				0x200000, 0x7a1099f0, BRF_GRA },
+	{ "redearth-simm3.6",				0x200000, 0xaeff8f54, BRF_GRA },
+	{ "redearth-simm3.7",				0x200000, 0xf770acd0, BRF_GRA },
+	{ "redearth-simm4.0",				0x200000, 0x301e56f2, BRF_GRA },
+	{ "redearth-simm4.1",				0x200000, 0x2048e103, BRF_GRA },
+	{ "redearth-simm4.2",				0x200000, 0xc9433455, BRF_GRA },
+	{ "redearth-simm4.3",				0x200000, 0xc02171a8, BRF_GRA },
+	{ "redearth-simm4.4",				0x200000, 0x2ddbf276, BRF_GRA },
+	{ "redearth-simm4.5",				0x200000, 0xfea820a6, BRF_GRA },
+	{ "redearth-simm4.6",				0x200000, 0xc7528df1, BRF_GRA },
+	{ "redearth-simm4.7",				0x200000, 0x2449cf3b, BRF_GRA },
+	{ "redearth-simm5.0",				0x200000, 0x424451b9, BRF_GRA },
+	{ "redearth-simm5.1",				0x200000, 0x9b8cb56b, BRF_GRA },
+};
+
+STD_ROM_PICK(redearthnr1)
+STD_ROM_FN(redearthnr1)
 
 // ------------------------------------------------------------------------------------
 
@@ -1396,7 +1560,7 @@ static INT32 redearthInit()
 
 struct BurnDriver BurnDrvSfiii = {
 	"sfiii", NULL, NULL, NULL, "1997",
-	"Street Fighter III: New Generation (Euro 970204)\0", NULL, "Capcom", "CPS-3",
+	"Street Fighter III: New Generation (Europe 970204)\0", NULL, "Capcom", "CPS-3",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, FBF_SF,
 	NULL, sfiiiRomInfo, sfiiiRomName, NULL, NULL, NULL, NULL, cps3InputInfo, sfiiieuroDIPInfo,
@@ -1484,6 +1648,16 @@ struct BurnDriver BurnDrvSfiii2j = {
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvSfiii2h = {
+	"sfiii2h", "sfiii2", NULL, NULL, "1997",
+	"Street Fighter III 2nd Impact: Giant Attack (Hispanic 970930)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, FBF_SF,
+	NULL, sfiii2hRomInfo, sfiii2hRomName, NULL, NULL, NULL, NULL, cps3InputInfo, hispanicDIPInfo,
+	sfiii2Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvSfiii2n = {
 	"sfiii2n", "sfiii2", NULL, NULL, "1997",
 	"Street Fighter III 2nd Impact: Giant Attack (Asia 970930, NO CD)\0", NULL, "Capcom", "CPS-3",
@@ -1496,7 +1670,7 @@ struct BurnDriver BurnDrvSfiii2n = {
 
 struct BurnDriver BurnDrvSfiii3 = {
 	"sfiii3", NULL, NULL, NULL, "1999",
-	"Street Fighter III 3rd Strike: Fight for the Future (Euro 990608)\0", NULL, "Capcom", "CPS-3",
+	"Street Fighter III 3rd Strike: Fight for the Future (Europe 990608)\0", NULL, "Capcom", "CPS-3",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, FBF_SF,
 	NULL, sfiii3RomInfo, sfiii3RomName, NULL, NULL, NULL, NULL, cps3InputInfo, euroDIPInfo,
@@ -1534,9 +1708,19 @@ struct BurnDriver BurnDrvSfiii3n = {
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvSfiii3na = {
+	"sfiii3na", "sfiii3", NULL, NULL, "1999",
+	"Street Fighter III 3rd Strike: Fight for the Future (Asia 990608, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
+	NULL, sfiii3naRomInfo, sfiii3naRomName, NULL, NULL, NULL, NULL, cps3InputInfo, asiaDIPInfo,
+	sfiii3Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvSfiii3r1 = {
 	"sfiii3r1", "sfiii3", NULL, NULL, "1999",
-	"Street Fighter III 3rd Strike: Fight for the Future (Euro 990512)\0", NULL, "Capcom", "CPS-3",
+	"Street Fighter III 3rd Strike: Fight for the Future (Europe 990512)\0", NULL, "Capcom", "CPS-3",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, FBF_SF,
 	NULL, sfiii3r1RomInfo, sfiii3r1RomName, NULL, NULL, NULL, NULL, cps3InputInfo, euroDIPInfo,
@@ -1574,10 +1758,20 @@ struct BurnDriver BurnDrvSfiii3nr1 = {
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvSfiii3nar1 = {
+	"sfiii3nar1", "sfiii3", NULL, NULL, "1999",
+	"Street Fighter III 3rd Strike: Fight for the Future (Asia 990512, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
+	NULL, sfiii3nar1RomInfo, sfiii3nar1RomName, NULL, NULL, NULL, NULL, cps3InputInfo, asiaDIPInfo,
+	sfiii3Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvJojo = {
 	"jojo", NULL, NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Euro 990128)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (Euro 990128)\0", NULL, NULL, NULL,
+	"JoJo's Venture (Europe 990128)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojoRomInfo, jojoRomName, NULL, NULL, NULL, NULL, jojoInputInfo, euroDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1586,18 +1780,28 @@ struct BurnDriver BurnDrvJojo = {
 
 struct BurnDriver BurnDrvJojou = {
 	"jojou", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (USA 990128)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (USA 990128)\0", NULL, NULL, NULL,
+	"JoJo's Venture (USA 990128)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojouRomInfo, jojouRomName, NULL, NULL, NULL, NULL, jojoInputInfo, usaDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvJojoa = {
+	"jojoa", "jojo", NULL, NULL, "1998",
+	"JoJo's Venture (Asia 990128)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
+	NULL, jojoaRomInfo, jojoaRomName, NULL, NULL, NULL, NULL, jojoInputInfo, asiaDIPInfo,
+	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvJojoj = {
 	"jojoj", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Japan 990128)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (Japan 990128)\0", NULL, NULL, NULL,
+	"JoJo no Kimyou na Bouken (Japan 990128)\0", NULL, "Capcom", "CPS-3",
+	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A (Japan 990128)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojojRomInfo, jojojRomName, NULL, NULL, NULL, NULL, jojoInputInfo, japanDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1606,8 +1810,8 @@ struct BurnDriver BurnDrvJojoj = {
 
 struct BurnDriver BurnDrvJojon = {
 	"jojon", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Asia 990128, NO CD)\0", NULL, "Capcom", "CPS-3",
-	L"JoJo's Venture\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A (Asia 990128, NO CD)\0", NULL, NULL, NULL,
+	"JoJo's Venture (Asia 990128, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojonRomInfo, jojonRomName, NULL, NULL, NULL, NULL, jojoInputInfo, asiaDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1616,8 +1820,8 @@ struct BurnDriver BurnDrvJojon = {
 
 struct BurnDriver BurnDrvJojor1 = {
 	"jojor1", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Euro 990108)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (Euro 990108)\0", NULL, NULL, NULL,
+	"JoJo's Venture (Europe 990108)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojor1RomInfo, jojor1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, euroDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1626,18 +1830,28 @@ struct BurnDriver BurnDrvJojor1 = {
 
 struct BurnDriver BurnDrvJojour1 = {
 	"jojour1", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (USA 990108)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (USA 990108)\0", NULL, NULL, NULL,
+	"JoJo's Venture (USA 990108)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojour1RomInfo, jojour1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, usaDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvJojoar1 = {
+	"jojoar1", "jojo", NULL, NULL, "1998",
+	"JoJo's Venture (Asia 990108)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
+	NULL, jojoar1RomInfo, jojoar1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, asiaDIPInfo,
+	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvJojojr1 = {
 	"jojojr1", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Japan 990108)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (Japan 990108)\0", NULL, NULL, NULL,
+	"JoJo no Kimyou na Bouken (Japan 990108)\0", NULL, "Capcom", "CPS-3",
+	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A (Japan 990108)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojojr1RomInfo, jojojr1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, japanDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1646,8 +1860,8 @@ struct BurnDriver BurnDrvJojojr1 = {
 
 struct BurnDriver BurnDrvJojonr1 = {
 	"jojonr1", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Asia 990108, NO CD)\0", NULL, "Capcom", "CPS-3",
-	L"JoJo's Venture\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A (Asia 990108, NO CD)\0", NULL, NULL, NULL,
+	"JoJo's Venture (Asia 990108, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojonr1RomInfo, jojonr1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, asiaDIPInfo,
 	jojor1Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1656,8 +1870,8 @@ struct BurnDriver BurnDrvJojonr1 = {
 
 struct BurnDriver BurnDrvJojor2 = {
 	"jojor2", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Euro 981202)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (Euro 981202)\0", NULL, NULL, NULL,
+	"JoJo's Venture (Europe 981202)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojor2RomInfo, jojor2RomName, NULL, NULL, NULL, NULL, jojoInputInfo, euroDIPInfo,
 	jojor2Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1666,18 +1880,28 @@ struct BurnDriver BurnDrvJojor2 = {
 
 struct BurnDriver BurnDrvJojour2 = {
 	"jojour2", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (USA 981202)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (USA 981202)\0", NULL, NULL, NULL,
+	"JoJo's Venture (USA 981202)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojour2RomInfo, jojour2RomName, NULL, NULL, NULL, NULL, jojoInputInfo, usaDIPInfo,
 	jojor2Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvJojoar2 = {
+	"jojoar2", "jojo", NULL, NULL, "1998",
+	"JoJo's Venture (Asia 981202)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
+	NULL, jojoar2RomInfo, jojoar2RomName, NULL, NULL, NULL, NULL, jojoInputInfo, asiaDIPInfo,
+	jojor2Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvJojojr2 = {
 	"jojojr2", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Japan 981202)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A\0JoJo's Venture (Japan 981202)\0", NULL, NULL, NULL,
+	"JoJo no Kimyou na Bouken (Japan 981202)\0", NULL, "Capcom", "CPS-3",
+	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A (Japan 981202)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, jojojr2RomInfo, jojojr2RomName, NULL, NULL, NULL, NULL, jojoInputInfo, japanDIPInfo,
 	jojor2Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1686,8 +1910,8 @@ struct BurnDriver BurnDrvJojojr2 = {
 
 struct BurnDriver BurnDrvJojonr2 = {
 	"jojonr2", "jojo", NULL, NULL, "1998",
-	"JoJo's Venture / JoJo no Kimyou na Bouken (Asia 981202, NO CD)\0", NULL, "Capcom", "CPS-3",
-	L"JoJo's Venture\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A (Asia 981202, NO CD)\0", NULL, NULL, NULL,
+	"JoJo's Venture (Asia 981202, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojonr2RomInfo, jojonr2RomName, NULL, NULL, NULL, NULL, jojoInputInfo, asiaDIPInfo,
 	jojor2Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1696,18 +1920,28 @@ struct BurnDriver BurnDrvJojonr2 = {
 
 struct BurnDriver BurnDrvJojoba = {
 	"jojoba", NULL, NULL, NULL, "1999",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990927)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523\0JoJo's Bizarre Adventure (Japan 990927)\0", NULL, NULL, NULL,
+	"JoJo's Bizarre Adventure (Europe  990927)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
-	NULL, jojobaRomInfo, jojobaRomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
+	NULL, jojobaRomInfo, jojobaRomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaneDIPInfo,
+	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
+struct BurnDriver BurnDrvJojobaj = {
+	"jojobaj", "jojoba", NULL, NULL, "1999",
+	"JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990927)\0", NULL, "Capcom", "CPS-3",
+	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Japan 990927)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
+	NULL, jojobajRomInfo, jojobajRomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
 struct BurnDriver BurnDrvJojoban = {
 	"jojoban", "jojoba", NULL, NULL, "1999",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990927, NO CD)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523\0JoJo's Bizarre Adventure (Japan 990927, NO CD)\0", NULL, NULL, NULL,
+	"JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990927, NO CD)\0", NULL, "Capcom", "CPS-3",
+	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Japan 990927, NO CD)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojobanRomInfo, jojobanRomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1716,8 +1950,8 @@ struct BurnDriver BurnDrvJojoban = {
 
 struct BurnDriver BurnDrvJojobane = {
 	"jojobane", "jojoba", NULL, NULL, "1999",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Euro 990927, NO CD)\0", NULL, "Capcom", "CPS-3",
-	L"JoJo's Bizarre Adventure\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Euro 990927, NO CD)\0", NULL, NULL, NULL,
+	"JoJo's Bizarre Adventure (Europe 990927, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojobaneRomInfo, jojobaneRomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaneDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1726,18 +1960,28 @@ struct BurnDriver BurnDrvJojobane = {
 
 struct BurnDriver BurnDrvJojobar1 = {
 	"jojobar1", "jojoba", NULL, NULL, "1999",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990913)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523\0JoJo's Bizarre Adventure (Japan 990913)\0", NULL, NULL, NULL,
+	"JoJo's Bizarre Adventure (Europe 990913)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
-	NULL, jojobar1RomInfo, jojobar1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
+	NULL, jojobar1RomInfo, jojobar1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaneDIPInfo,
+	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
+struct BurnDriver BurnDrvJojobajr1 = {
+	"jojobajr1", "jojoba", NULL, NULL, "1999",
+	"JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990913)\0", NULL, "Capcom", "CPS-3",
+	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Japan 990913)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
+	NULL, jojobajr1RomInfo, jojobajr1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
 struct BurnDriver BurnDrvJojobanr1 = {
 	"jojobanr1", "jojoba", NULL, NULL, "1999",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990913, NO CD)\0", NULL, "Capcom", "CPS-3",
-	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523\0JoJo's Bizarre Adventure (Japan 990913, NO CD)\0", NULL, NULL, NULL,
+	"JoJo no Kimyou na Bouken: Mirai e no Isan (Japan 990913, NO CD)\0", NULL, "Capcom", "CPS-3",
+	L"\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Japan 990913, NO CD)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojobanr1RomInfo, jojobanr1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1746,8 +1990,8 @@ struct BurnDriver BurnDrvJojobanr1 = {
 
 struct BurnDriver BurnDrvJojobaner1 = {
 	"jojobaner1", "jojoba", NULL, NULL, "1999",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Euro 990913, NO CD)\0", NULL, "Capcom", "CPS-3",
-	L"JoJo's Bizarre Adventure\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Euro 990913, NO CD)\0", NULL, NULL, NULL,
+	"JoJo's Bizarre Adventure (Europe 990913, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojobaner1RomInfo, jojobaner1RomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaneDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1756,8 +2000,8 @@ struct BurnDriver BurnDrvJojobaner1 = {
 
 struct BurnDriver BurnDrvRedearth = {
 	"redearth", NULL, NULL, NULL, "1996",
-	"Red Earth / War-Zard (Euro 961121)\0", NULL, "Capcom", "CPS-3",
-	L"Red Earth\0War-Zard (Euro 961121)\0", NULL, NULL, NULL,
+	"Red Earth (Europe 961121)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, redearthRomInfo, redearthRomName, NULL, NULL, NULL, NULL, cps3InputInfo, redearthDIPInfo,
 	redearthInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1766,18 +2010,28 @@ struct BurnDriver BurnDrvRedearth = {
 
 struct BurnDriver BurnDrvWarzard = {
 	"warzard", "redearth", NULL, NULL, "1996",
-	"War-Zard / Red Earth (Japan 961121)\0", NULL, "Capcom", "CPS-3",
-	L"War-Zard\0Red Earth (Japan 961121)\0", NULL, NULL, NULL,
+	"Warzard (Japan 961121)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, warzardRomInfo, warzardRomName, NULL, NULL, NULL, NULL, cps3InputInfo, warzardDIPInfo,
 	redearthInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvRedearthn = {
+	"redearthn", "redearth", NULL, NULL, "1996",
+	"Red Earth (Asia 961121, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
+	NULL, redearthnRomInfo, redearthnRomName, NULL, NULL, NULL, NULL, cps3InputInfo, redearthnDIPInfo,
+	redearthInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 struct BurnDriver BurnDrvRedearthr1 = {
 	"redearthr1", "redearth", NULL, NULL, "1996",
-	"Red Earth / War-Zard (Euro 961023)\0", NULL, "Capcom", "CPS-3",
-	L"Red Earth\0War-Zard (Euro 961023)\0", NULL, NULL, NULL,
+	"Red Earth (Europe 961023)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, redearthr1RomInfo, redearthr1RomName, NULL, NULL, NULL, NULL, cps3InputInfo, redearthDIPInfo,
 	redearthInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
@@ -1786,45 +2040,54 @@ struct BurnDriver BurnDrvRedearthr1 = {
 
 struct BurnDriver BurnDrvWarzardr1 = {
 	"warzardr1", "redearth", NULL, NULL, "1996",
-	"War-Zard / Red Earth (Japan 961023)\0", NULL, "Capcom", "CPS-3",
-	L"War-Zard\0Red Earth (Japan 961023)\0", NULL, NULL, NULL,
+	"Warzard (Japan 961023)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, warzardr1RomInfo, warzardr1RomName, NULL, NULL, NULL, NULL, cps3InputInfo, warzardDIPInfo,
 	redearthInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
+struct BurnDriver BurnDrvRedearthnr1 = {
+	"redearthnr1", "redearth", NULL, NULL, "1996",
+	"Red Earth (Asia 961023, NO CD)\0", NULL, "Capcom", "CPS-3",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
+	NULL, redearthnr1RomInfo, redearthnr1RomName, NULL, NULL, NULL, NULL, cps3InputInfo, redearthnDIPInfo,
+	redearthInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
+	384, 224, 4, 3
+};
+
 // CPS-3 Hacks
 
-// --------------------------------------------------------------------------
-// Street Fighter III: New Generation [BossHack] [Hack by Mrstiller & Yumeji]
-// --------------------------------------------------------------------------
-
+// ----------------------------------------------
+// Street Fighter III: New Generation (Boss Hack)
+// ----------------------------------------------
 static struct BurnRomInfo sfiiibhRomDesc[] = {
 
-	{ "sfiii_euro.29f400.u2",	0x080000, 0x27699ddc, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	{ "sfiii_asia_nocd.29f400.u2",			0x080000, 0xca2b715f, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 
-	{ "sfiiibh-simm1.0",		0x200000, 0x0beaed86, BRF_ESS | BRF_PRG }, \
-	{ "sfiiibh-simm1.1",		0x200000, 0xe5c19320, BRF_ESS | BRF_PRG }, \
-	{ "sfiiibh-simm1.2",		0x200000, 0x316b87c2, BRF_ESS | BRF_PRG }, \
-	{ "sfiiibh-simm1.3",		0x200000, 0x46d63ec8, BRF_ESS | BRF_PRG }, \
-	{ "sfiii-simm3.0",			0x200000, 0x080b3bd3, BRF_GRA }, \
-	{ "sfiii-simm3.1",			0x200000, 0x5c356f2f, BRF_GRA }, \
-	{ "sfiii-simm3.2",			0x200000, 0xf9c97a45, BRF_GRA }, \
-	{ "sfiii-simm3.3",			0x200000, 0x09de3ead, BRF_GRA }, \
-	{ "sfiii-simm3.4",			0x200000, 0x7dd7e1f3, BRF_GRA }, \
-	{ "sfiii-simm3.5",			0x200000, 0x47a03a3a, BRF_GRA }, \
-	{ "sfiii-simm3.6",			0x200000, 0xe9eb7a26, BRF_GRA }, \
-	{ "sfiii-simm3.7",			0x200000, 0x7f44395c, BRF_GRA }, \
-	{ "sfiii-simm4.0",			0x200000, 0x9ac080fc, BRF_GRA }, \
-	{ "sfiii-simm4.1",			0x200000, 0x6e2c4c94, BRF_GRA }, \
-	{ "sfiii-simm4.2",			0x200000, 0x8afc22d4, BRF_GRA }, \
-	{ "sfiii-simm4.3",			0x200000, 0x9f3873b8, BRF_GRA }, \
-	{ "sfiii-simm4.4",			0x200000, 0x166b3c97, BRF_GRA }, \
-	{ "sfiii-simm4.5",			0x200000, 0xe5ea2547, BRF_GRA }, \
-	{ "sfiii-simm4.6",			0x200000, 0xe85b9fdd, BRF_GRA }, \
-	{ "sfiii-simm4.7",			0x200000, 0x362c01b7, BRF_GRA }, \
-	{ "sfiii-simm5.0",			0x200000, 0x9bc108b2, BRF_GRA }, \
+	{ "sfiiibh-simm1.0",		0x200000, 0x0beaed86, BRF_ESS | BRF_PRG },
+	{ "sfiiibh-simm1.1",		0x200000, 0xe5c19320, BRF_ESS | BRF_PRG },
+	{ "sfiiibh-simm1.2",		0x200000, 0x316b87c2, BRF_ESS | BRF_PRG },
+	{ "sfiiibh-simm1.3",		0x200000, 0x46d63ec8, BRF_ESS | BRF_PRG },
+	{ "sfiii-simm3.0",			0x200000, 0x080b3bd3, BRF_GRA },
+	{ "sfiii-simm3.1",			0x200000, 0x5c356f2f, BRF_GRA },
+	{ "sfiii-simm3.2",			0x200000, 0xf9c97a45, BRF_GRA },
+	{ "sfiii-simm3.3",			0x200000, 0x09de3ead, BRF_GRA },
+	{ "sfiii-simm3.4",			0x200000, 0x7dd7e1f3, BRF_GRA },
+	{ "sfiii-simm3.5",			0x200000, 0x47a03a3a, BRF_GRA },
+	{ "sfiii-simm3.6",			0x200000, 0xe9eb7a26, BRF_GRA },
+	{ "sfiii-simm3.7",			0x200000, 0x7f44395c, BRF_GRA },
+	{ "sfiii-simm4.0",			0x200000, 0x9ac080fc, BRF_GRA },
+	{ "sfiii-simm4.1",			0x200000, 0x6e2c4c94, BRF_GRA },
+	{ "sfiii-simm4.2",			0x200000, 0x8afc22d4, BRF_GRA },
+	{ "sfiii-simm4.3",			0x200000, 0x9f3873b8, BRF_GRA },
+	{ "sfiii-simm4.4",			0x200000, 0x166b3c97, BRF_GRA },
+	{ "sfiii-simm4.5",			0x200000, 0xe5ea2547, BRF_GRA },
+	{ "sfiii-simm4.6",			0x200000, 0xe85b9fdd, BRF_GRA },
+	{ "sfiii-simm4.7",			0x200000, 0x362c01b7, BRF_GRA },
+	{ "sfiii-simm5.0",			0x200000, 0x9bc108b2, BRF_GRA },
 	{ "sfiii-simm5.1",			0x200000, 0xc6f1c066, BRF_GRA },
 };
 
@@ -1832,22 +2095,21 @@ STD_ROM_PICK(sfiiibh)
 STD_ROM_FN(sfiiibh)
 
 struct BurnDriver BurnDrvSfiiibh = {
-	"sfiiibh", "sfiii", NULL, NULL, "2017",
-	"Street Fighter III: New Generation (Boss Hack)\0", NULL, "hack", "CPS-3",
+	"sfiiibh", "sfiii", NULL, NULL, "201?",
+	"Street Fighter III: New Generation (Boss Hack)\0", NULL, "hack (Yumeji)", "CPS-3",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
-	NULL, sfiiibhRomInfo, sfiiibhRomName, NULL, NULL, NULL, NULL, cps3InputInfo, sfiiieuroDIPInfo,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
+	NULL, sfiiibhRomInfo, sfiiibhRomName, NULL, NULL, NULL, NULL, cps3InputInfo, sfiiiasiaDIPInfo,
 	sfiiiInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
-// -----------------------------------------------------------------------------------
-// Street Fighter III 2nd Impact: Giant Attack [BossHack] [Hack by Mrstiller & Yumeji]
-// -----------------------------------------------------------------------------------
-
+// -------------------------------------------------------
+// Street Fighter III 2nd Impact: Giant Attack (Boss Hack)
+// -------------------------------------------------------
 static struct BurnRomInfo sfiii2bhRomDesc[] = {
 
-	{ "sfiii2_usa.29f400.u2",	0x080000, 0x75dd72e0, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	{ "sfiii2_asia_nocd.29f400.u2",			0x080000, 0xfd297c0d, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 
 	{ "sfiii2bhv2-simm1.0",		0x200000, 0x1c74e097, BRF_ESS | BRF_PRG }, \
 	{ "sfiii2bhv2-simm1.1",		0x200000, 0x3aa0f060, BRF_ESS | BRF_PRG }, \
@@ -1887,22 +2149,21 @@ STD_ROM_PICK(sfiii2bh)
 STD_ROM_FN(sfiii2bh)
 
 struct BurnDriver BurnDrvSfiii2bh = {
-	"sfiii2bh", "sfiii2", NULL, NULL, "2017",
-	"Street Fighter III 2nd Impact: Giant Attack (Boss Hack)\0", NULL, "hack", "CPS-3",
+	"sfiii2bh", "sfiii2", NULL, NULL, "201?",
+	"Street Fighter III 2nd Impact: Giant Attack (Boss Hack)\0", NULL, "hack (Yumeji)", "CPS-3",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
-	NULL, sfiii2bhRomInfo, sfiii2bhRomName, NULL, NULL, NULL, NULL, cps3InputInfo, sfiiiusaDIPInfo,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
+	NULL, sfiii2bhRomInfo, sfiii2bhRomName, NULL, NULL, NULL, NULL, cps3InputInfo, sfiiiasiaDIPInfo,
 	sfiii2Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
-// -------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 // Street Fighter III 3rd Strike: Fight for the Future (4rd Arrange Edition 2013)
-// -------------------------------------------------------------------------
-
+// ------------------------------------------------------------------------------
 static struct BurnRomInfo sfiii4nRomDesc[] = {
 
-	{ "sfiii3_japan_nocd.29f400.u2",	0x080000, 0x1EDC6366, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	{ "sfiii3_japan_nocd.29f400.u2",	0x080000, 0x1edc6366, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 
 	{ "4rd-simm1.0",					0x200000, 0xca97f95e, BRF_ESS | BRF_PRG },
 	{ "4rd-simm1.1",					0x200000, 0x5bc7faa6, BRF_ESS | BRF_PRG },
@@ -1959,53 +2220,52 @@ struct BurnDriver BurnDrvSfiii4n = {
 	384, 224, 4, 3
 };
 
-// -------------------------------------------------------------------------------------------
-// Street Fighter III 3rd Strike: Fight for the Future [BossHack] [Hack by Mrstiller & Yumeji]
-// -------------------------------------------------------------------------------------------
-
+// ---------------------------------------------------------------
+// Street Fighter III 3rd Strike: Fight for the Future (Boss Hack)
+// ---------------------------------------------------------------
 static struct BurnRomInfo sfiii3bhRomDesc[] = {
 
-	{ "sfiii3_euro.29f400.u2",	0x080000, 0x30bbf293, BRF_ESS | BRF_BIOS },	// SH-2 Bios
+	{ "sfiii3_japan_nocd.29f400.u2",		0x080000, 0x1edc6366, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 
-	{ "sfiii3bh-simm1.0",		0x200000, 0x2753fad5, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3bh-simm1.1",		0x200000, 0xfca5f8e6, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3bh-simm1.2",		0x200000, 0xcd6367b3, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3bh-simm1.3",		0x200000, 0xe5c4245a, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3-simm2.0",			0x200000, 0x06eb969e, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3-simm2.1",			0x200000, 0xe7039f82, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3-simm2.2",			0x200000, 0x645c96f7, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3-simm2.3",			0x200000, 0x610efab1, BRF_ESS | BRF_PRG }, \
-	{ "sfiii3-simm3.0",			0x200000, 0x7baa1f79, BRF_GRA }, \
-	{ "sfiii3-simm3.1",			0x200000, 0x234bf8fe, BRF_GRA }, \
-	{ "sfiii3-simm3.2",			0x200000, 0xd9ebc308, BRF_GRA }, \
-	{ "sfiii3-simm3.3",			0x200000, 0x293cba77, BRF_GRA }, \
-	{ "sfiii3-simm3.4",			0x200000, 0x6055e747, BRF_GRA }, \
-	{ "sfiii3-simm3.5",			0x200000, 0x499aa6fc, BRF_GRA }, \
-	{ "sfiii3-simm3.6",			0x200000, 0x6c13879e, BRF_GRA }, \
-	{ "sfiii3-simm3.7",			0x200000, 0xcf4f8ede, BRF_GRA }, \
-	{ "sfiii3-simm4.0",			0x200000, 0x091fd5ba, BRF_GRA }, \
-	{ "sfiii3-simm4.1",			0x200000, 0x0bca8917, BRF_GRA }, \
-	{ "sfiii3-simm4.2",			0x200000, 0xa0fd578b, BRF_GRA }, \
-	{ "sfiii3-simm4.3",			0x200000, 0x4bf8c699, BRF_GRA }, \
-	{ "sfiii3-simm4.4",			0x200000, 0x137b8785, BRF_GRA }, \
-	{ "sfiii3-simm4.5",			0x200000, 0x4fb70671, BRF_GRA }, \
-	{ "sfiii3-simm4.6",			0x200000, 0x832374a4, BRF_GRA }, \
-	{ "sfiii3-simm4.7",			0x200000, 0x1c88576d, BRF_GRA }, \
-	{ "sfiii3-simm5.0",			0x200000, 0xc67d9190, BRF_GRA }, \
-	{ "sfiii3-simm5.1",			0x200000, 0x6cb79868, BRF_GRA }, \
-	{ "sfiii3-simm5.2",			0x200000, 0xdf69930e, BRF_GRA }, \
-	{ "sfiii3-simm5.3",			0x200000, 0x333754e0, BRF_GRA }, \
-	{ "sfiii3-simm5.4",			0x200000, 0x78f6d417, BRF_GRA }, \
-	{ "sfiii3-simm5.5",			0x200000, 0x8ccad9b1, BRF_GRA }, \
-	{ "sfiii3-simm5.6",			0x200000, 0x85de59e5, BRF_GRA }, \
-	{ "sfiii3-simm5.7",			0x200000, 0xee7e29b3, BRF_GRA }, \
-	{ "sfiii3-simm6.0",			0x200000, 0x8da69042, BRF_GRA }, \
-	{ "sfiii3-simm6.1",			0x200000, 0x1c8c7ac4, BRF_GRA }, \
-	{ "sfiii3-simm6.2",			0x200000, 0xa671341d, BRF_GRA }, \
-	{ "sfiii3-simm6.3",			0x200000, 0x1a990249, BRF_GRA }, \
-	{ "sfiii3-simm6.4",			0x200000, 0x20cb39ac, BRF_GRA }, \
-	{ "sfiii3-simm6.5",			0x200000, 0x5f844b2f, BRF_GRA }, \
-	{ "sfiii3-simm6.6",			0x200000, 0x450e8d28, BRF_GRA }, \
+	{ "sfiii3bh-simm1.0",		0x200000, 0x2753fad5, BRF_ESS | BRF_PRG },
+	{ "sfiii3bh-simm1.1",		0x200000, 0xfca5f8e6, BRF_ESS | BRF_PRG },
+	{ "sfiii3bh-simm1.2",		0x200000, 0xcd6367b3, BRF_ESS | BRF_PRG },
+	{ "sfiii3bh-simm1.3",		0x200000, 0xe5c4245a, BRF_ESS | BRF_PRG },
+	{ "sfiii3-simm2.0",			0x200000, 0x06eb969e, BRF_ESS | BRF_PRG },
+	{ "sfiii3-simm2.1",			0x200000, 0xe7039f82, BRF_ESS | BRF_PRG },
+	{ "sfiii3-simm2.2",			0x200000, 0x645c96f7, BRF_ESS | BRF_PRG },
+	{ "sfiii3-simm2.3",			0x200000, 0x610efab1, BRF_ESS | BRF_PRG },
+	{ "sfiii3-simm3.0",			0x200000, 0x7baa1f79, BRF_GRA },
+	{ "sfiii3-simm3.1",			0x200000, 0x234bf8fe, BRF_GRA },
+	{ "sfiii3-simm3.2",			0x200000, 0xd9ebc308, BRF_GRA },
+	{ "sfiii3-simm3.3",			0x200000, 0x293cba77, BRF_GRA },
+	{ "sfiii3-simm3.4",			0x200000, 0x6055e747, BRF_GRA },
+	{ "sfiii3-simm3.5",			0x200000, 0x499aa6fc, BRF_GRA },
+	{ "sfiii3-simm3.6",			0x200000, 0x6c13879e, BRF_GRA },
+	{ "sfiii3-simm3.7",			0x200000, 0xcf4f8ede, BRF_GRA },
+	{ "sfiii3-simm4.0",			0x200000, 0x091fd5ba, BRF_GRA },
+	{ "sfiii3-simm4.1",			0x200000, 0x0bca8917, BRF_GRA },
+	{ "sfiii3-simm4.2",			0x200000, 0xa0fd578b, BRF_GRA },
+	{ "sfiii3-simm4.3",			0x200000, 0x4bf8c699, BRF_GRA },
+	{ "sfiii3-simm4.4",			0x200000, 0x137b8785, BRF_GRA },
+	{ "sfiii3-simm4.5",			0x200000, 0x4fb70671, BRF_GRA },
+	{ "sfiii3-simm4.6",			0x200000, 0x832374a4, BRF_GRA },
+	{ "sfiii3-simm4.7",			0x200000, 0x1c88576d, BRF_GRA },
+	{ "sfiii3-simm5.0",			0x200000, 0xc67d9190, BRF_GRA },
+	{ "sfiii3-simm5.1",			0x200000, 0x6cb79868, BRF_GRA },
+	{ "sfiii3-simm5.2",			0x200000, 0xdf69930e, BRF_GRA },
+	{ "sfiii3-simm5.3",			0x200000, 0x333754e0, BRF_GRA },
+	{ "sfiii3-simm5.4",			0x200000, 0x78f6d417, BRF_GRA },
+	{ "sfiii3-simm5.5",			0x200000, 0x8ccad9b1, BRF_GRA },
+	{ "sfiii3-simm5.6",			0x200000, 0x85de59e5, BRF_GRA },
+	{ "sfiii3-simm5.7",			0x200000, 0xee7e29b3, BRF_GRA },
+	{ "sfiii3-simm6.0",			0x200000, 0x8da69042, BRF_GRA },
+	{ "sfiii3-simm6.1",			0x200000, 0x1c8c7ac4, BRF_GRA },
+	{ "sfiii3-simm6.2",			0x200000, 0xa671341d, BRF_GRA },
+	{ "sfiii3-simm6.3",			0x200000, 0x1a990249, BRF_GRA },
+	{ "sfiii3-simm6.4",			0x200000, 0x20cb39ac, BRF_GRA },
+	{ "sfiii3-simm6.5",			0x200000, 0x5f844b2f, BRF_GRA },
+	{ "sfiii3-simm6.6",			0x200000, 0x450e8d28, BRF_GRA },
 	{ "sfiii3-simm6.7",			0x200000, 0xcc5f4187, BRF_GRA },
 };
 
@@ -2013,11 +2273,11 @@ STD_ROM_PICK(sfiii3bh)
 STD_ROM_FN(sfiii3bh)
 
 struct BurnDriver BurnDrvSfiii3bh = {
-	"sfiii3bh", "sfiii3", NULL, NULL, "2017",
-	"Street Fighter III 3rd Strike: Fight for the Future (Boss Hack)\0", NULL, "hack", "CPS-3",
+	"sfiii3bh", "sfiii3", NULL, NULL, "201?",
+	"Street Fighter III 3rd Strike: Fight for the Future (Boss Hack)\0", NULL, "hack (Yumeji)", "CPS-3",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
-	NULL, sfiii3bhRomInfo, sfiii3bhRomName, NULL, NULL, NULL, NULL, cps3InputInfo, euroDIPInfo,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, FBF_SF,
+	NULL, sfiii3bhRomInfo, sfiii3bhRomName, NULL, NULL, NULL, NULL, cps3InputInfo, japanDIPInfo,
 	sfiii3Init, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
@@ -2031,7 +2291,6 @@ struct BurnDriver BurnDrvSfiii3bh = {
 // 1 - Original VS Screen
 // 1 - Default HUD
 // -------------------------------------------------------------------------
-
 static struct BurnRomInfo sfiii3thRomDesc[] = {
 
 	{ "sfiii3_japan_nocd.29f400.u2",	0x080000, 0x1edc6366, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -2094,7 +2353,6 @@ struct BurnDriver BurnDrvSfiii3th = {
 // -------------------------------------------------------------------------
 // Street Fighter III 3rd Strike: Fight for the Future (Widescreen 20220908)
 // -------------------------------------------------------------------------
-
 static struct BurnRomInfo sfiii3wsRomDesc[] = {
 
 	{ "sfiii3_japan_nocd.29f400.u2",	0x080000, 0x1edc6366, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -2154,10 +2412,9 @@ struct BurnDriver BurnDrvSfiii3ws = {
 	496, 224, 16, 9
 };
 
-// -------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Street Fighter III 3rd Strike: Fight for the Future (4rd Strike 2011-07-17)
-// -------------------------------------------------------------------------
-
+// ---------------------------------------------------------------------------
 static struct BurnRomInfo sfiii4fsRomDesc[] = {
 
 	{ "sfiii3_japan_nocd.29f400.u2",	0x080000, 0x1edc6366, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -2217,10 +2474,9 @@ struct BurnDriver BurnDrvsfiii4fs = {
 	384, 224, 4, 3
 };
 
-// ---------------------------------------------------------------------------------------
-// JoJo's Bizarre Adventure RAINBOW EDITION
-// ---------------------------------------------------------------------------------------
-
+// ------------------------------------------------------
+// JoJo's Bizarre Adventure (Rainbow Edition v1.0.1 2021)
+// ------------------------------------------------------
 static struct BurnRomInfo jojobanrbRomDesc[] = {
 	{ "jojoba_japan_nocd.29f400.u2",	0x080000, 0x4dab19f5, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 	
@@ -2263,17 +2519,17 @@ STD_ROM_FN(jojobanrb)
 
 struct BurnDriver BurnDrvJojobanrb = {
 	"jojobanrb", "jojoba", NULL, NULL, "2021",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Rainbow Edition v1.0.1 2021)\0", NULL, "hack", "CPS-3",
-	L"JoJo's Bizarre Adventure\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Rainbow Edition v1.0.1 2021)\0", NULL, NULL, NULL,
+	"JoJo's Bizarre Adventure (Rainbow Edition v1.0.1 2021)\0", NULL, "hack", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojobanrbRomInfo, jojobanrbRomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
-// ---------------------------------------------------------------------------------------
-// JoJo's Bizarre Adventure: Heritage for the Future (Roman Cancel Edition)
-// ---------------------------------------------------------------------------------------
+// ----------------------------------------------------
+// JoJo's Bizarre Adventure (Roman Cancel Edition 2021)
+// ----------------------------------------------------
 
 static struct BurnRomInfo jojobanrcRomDesc[] = {
 	{ "jojoba_japan_nocd.29f400.u2",	0x080000, 0x4dab19f5, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -2317,18 +2573,17 @@ STD_ROM_FN(jojobanrc)
 
 struct BurnDriver BurnDrvJojobanrc = {
 	"jojobanrc", "jojoba", NULL, NULL, "2021",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Roman Cancel Edition 2021)\0", NULL, "hack", "CPS-3",
-	L"JoJo's Bizarre Adventure\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Roman Cancel Edition 2021)\0", NULL, NULL, NULL,
+	"JoJo's Bizarre Adventure (Roman Cancel Edition 2021)\0", NULL, "hack", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojobanrcRomInfo, jojobanrcRomName, NULL, NULL, NULL, NULL, jojobanrcInputInfo, jojobaDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
-// ---------------------------------------------------------------------------------------
-// JoJo's Bizarre Adventure: Heritage for the Future (Alessi/Child Mode)
-// ---------------------------------------------------------------------------------------
-
+// -------------------------------------------------
+// JoJo's Bizarre Adventure (Alessi/Child Mode 2019)
+// -------------------------------------------------
 static struct BurnRomInfo jojobanchRomDesc[] = {
 	{ "jojoba_japan_nocd.29f400.u2",	0x080000, 0x4dab19f5, BRF_ESS | BRF_BIOS },	// SH-2 Bios
 	
@@ -2371,17 +2626,17 @@ STD_ROM_FN(jojobanch)
 
 struct BurnDriver BurnDrvJojobanch = {
 	"jojobanch", "jojoba", NULL, NULL, "2019",
-	"JoJo's Bizarre Adventure: Heritage for the Future / JoJo no Kimyou na Bouken: Mirai e no Isan (Alessi/Child Mode 2019)\0", NULL, "hack", "CPS-3",
-	L"JoJo's Bizarre Adventure\0\u30B8\u30E7\u30B8\u30E7\u306E \u5947\u5999\u306A\u5192\u967A: \u672A\u6765\u3078\u306E\u907A\u7523 (Alessi/Child Mode 2019)\0", NULL, NULL, NULL,
+	"JoJo's Bizarre Adventure (Alessi/Child Mode 2019)\0", NULL, "hack", "CPS-3",
+	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS3 | HARDWARE_CAPCOM_CPS3_NO_CD, GBF_VSFIGHT, 0,
 	NULL, jojobanchRomInfo, jojobanchRomName, NULL, NULL, NULL, NULL, jojoInputInfo, jojobaDIPInfo,
 	jojobaInit, cps3Exit, cps3Frame, DrvCps3Draw, cps3Scan, &cps3_palette_change, 0x40000,
 	384, 224, 4, 3
 };
 
-// -----------------------------------------
-// Red Earth / War-Zard (Easy Password Hack)
-// -----------------------------------------
+// -------------------------------
+// Red Earth (Easy Password, Hack)
+// -------------------------------
 static struct BurnRomInfo redearthepRomDesc[] = {
 
 	{ "redearth_asia_nocd.29f400.u2",		0x080000, 0x7a4f0851, BRF_ESS | BRF_BIOS },	// SH-2 Bios
@@ -2415,7 +2670,7 @@ STD_ROM_FN(redearthep)
 
 struct BurnDriver BurnDrvRedearthep = {
 	"redearthep", "redearth", NULL, NULL, "2023",
-	"Red Earth / War-Zard (Easy Password, Hack)\0", NULL, "hack", "CPS-3",
+	"Red Earth (Easy Password, Hack)\0", NULL, "hack", "CPS-3",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS3, GBF_VSFIGHT, 0,
 	NULL, redearthepRomInfo, redearthepRomName, NULL, NULL, NULL, NULL, cps3InputInfo, redearthnDIPInfo,

--- a/src/burn/drv/dataeast/d_deco32.cpp
+++ b/src/burn/drv/dataeast/d_deco32.cpp
@@ -4839,13 +4839,13 @@ struct BurnDriver BurnDrvNslasheru = {
 };
 
 
-// Tattoo Assassins (US prototype)
+// Tattoo Assassins (US prototype, Mar 14 1995)
 
 static struct BurnRomInfo tattassRomDesc[] = {
 	{ "pp44.cpu",		0x80000, 0xc3ca5b49, 1 | BRF_PRG | BRF_ESS }, //  0 ARM Code
 	{ "pp45.cpu",		0x80000, 0xd3f30de0, 1 | BRF_PRG | BRF_ESS }, //  1
 
-	{ "u7.snd",		0x10000, 0x6947be8a, 2 | BRF_PRG | BRF_ESS }, //  2 M6809 Code
+	{ "u7.snd",			0x10000, 0xa7228077, 2 | BRF_PRG | BRF_ESS }, //  2 M6809 Code
 
 	{ "abak_b01.s02",	0x80000, 0xbc805680, 3 | BRF_GRA },           //  3 Tilemap 0&1 Tiles & Characters (Encrypted)
 	{ "abak_b01.s13",	0x80000, 0x350effcd, 3 | BRF_GRA },           //  4
@@ -4895,10 +4895,10 @@ static struct BurnRomInfo tattassRomDesc[] = {
 	{ "ob2_c2.b3",		0x80000, 0x90fe5f4f, 6 | BRF_GRA },           // 45
 	{ "ob2_c3.b3",		0x80000, 0xe3517e6e, 6 | BRF_GRA },           // 46
 
-	{ "u17.snd",		0x80000, 0xb945c18d, 7 | BRF_GRA },           // 47 BSMT Samples
-	{ "u21.snd",		0x80000, 0x10b2110c, 7 | BRF_GRA },           // 48
-	{ "u36.snd",		0x80000, 0x3b73abe2, 7 | BRF_GRA },           // 49
-	{ "u37.snd",		0x80000, 0x986066b5, 7 | BRF_GRA },           // 50
+	{ "u17.snd",		0x80000, 0x49303539, 7 | BRF_GRA },           // 47 BSMT Samples
+	{ "u21.snd",		0x80000, 0x0ad8bc18, 7 | BRF_GRA },           // 48
+	{ "u36.snd",		0x80000, 0xf558947b, 7 | BRF_GRA },           // 49
+	{ "u37.snd",		0x80000, 0x7a3190bc, 7 | BRF_GRA },           // 50
 
 	{ "eeprom-tattass.bin",	0x00400, 0x7140f40c, 8 | BRF_PRG | BRF_ESS }, // 51 Default Settings
 
@@ -4917,7 +4917,7 @@ static INT32 TattassInit()
 
 struct BurnDriver BurnDrvTattass = {
 	"tattass", NULL, NULL, NULL, "1994",
-	"Tattoo Assassins (US prototype)\0", NULL, "Data East Pinball", "DECO 32",
+	"Tattoo Assassins (US prototype, Mar 14 1995)\0", NULL, "Data East Pinball", "DECO 32",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 2, HARDWARE_PREFIX_DATAEAST, GBF_VSFIGHT, 0,
 	NULL, tattassRomInfo, tattassRomName, NULL, NULL, NULL, NULL, TattassInputInfo, TattassDIPInfo,
@@ -4932,7 +4932,7 @@ static struct BurnRomInfo tattassaRomDesc[] = {
 	{ "rev232a.000",	0x80000, 0x1a357112, 1 | BRF_PRG | BRF_ESS }, //  0 ARM Code
 	{ "rev232a.001",	0x80000, 0x550245d4, 1 | BRF_PRG | BRF_ESS }, //  1
 
-	{ "u7.snd",		0x10000, 0x6947be8a, 2 | BRF_PRG | BRF_ESS }, //  2 M6809 Code
+	{ "u7.snd",			0x10000, 0xa7228077, 2 | BRF_PRG | BRF_ESS }, //  2 M6809 Code
 
 	{ "abak_b01.s02",	0x80000, 0xbc805680, 3 | BRF_GRA },           //  3 Tilemap 0&1 Tiles & Characters (Encrypted)
 	{ "abak_b01.s13",	0x80000, 0x350effcd, 3 | BRF_GRA },           //  4
@@ -4982,10 +4982,10 @@ static struct BurnRomInfo tattassaRomDesc[] = {
 	{ "ob2_c2.b3",		0x80000, 0x90fe5f4f, 6 | BRF_GRA },           // 45
 	{ "ob2_c3.b3",		0x80000, 0xe3517e6e, 6 | BRF_GRA },           // 46
 
-	{ "u17.snd",		0x80000, 0xb945c18d, 7 | BRF_GRA },           // 47 BSMT Samples
-	{ "u21.snd",		0x80000, 0x10b2110c, 7 | BRF_GRA },           // 48
-	{ "u36.snd",		0x80000, 0x3b73abe2, 7 | BRF_GRA },           // 49
-	{ "u37.snd",		0x80000, 0x986066b5, 7 | BRF_GRA },           // 50
+	{ "u17.snd",		0x80000, 0x49303539, 7 | BRF_GRA },           // 47 BSMT Samples
+	{ "u21.snd",		0x80000, 0x0ad8bc18, 7 | BRF_GRA },           // 48
+	{ "u36.snd",		0x80000, 0xf558947b, 7 | BRF_GRA },           // 49
+	{ "u37.snd",		0x80000, 0x7a3190bc, 7 | BRF_GRA },           // 50
 
 	{ "eeprom-tattass.bin",	0x00400, 0x7140f40c, 8 | BRF_PRG | BRF_ESS }, // 51 Default Settings
 
@@ -4999,10 +4999,91 @@ STD_ROM_FN(tattassa)
 
 struct BurnDriver BurnDrvTattassa = {
 	"tattassa", "tattass", NULL, NULL, "1994",
-	"Tattoo Assassins (Asia prototype)\0", NULL, "Data East Pinball", "DECO 32",
+	"Tattoo Assassins (Asia prototype, Mar 14 1995)\0", NULL, "Data East Pinball", "DECO 32",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_PREFIX_DATAEAST, GBF_VSFIGHT, 0,
 	NULL, tattassaRomInfo, tattassaRomName, NULL, NULL, NULL, NULL, TattassInputInfo, TattassDIPInfo,
+	TattassInit, DrvExit, DrvBSMTFrame, NslasherDraw, DrvScan, &DrvRecalc, 0x800,
+	320, 240, 4, 3
+};
+
+// Tattoo Assassins (US prototype, Mar 14 1995, Older sound)
+
+static struct BurnRomInfo tattassoRomDesc[] = {
+	{ "pp44.cpu",		0x80000, 0xc3ca5b49, 1 | BRF_PRG | BRF_ESS }, //  0 ARM Code
+	{ "pp45.cpu",		0x80000, 0xd3f30de0, 1 | BRF_PRG | BRF_ESS }, //  1
+
+	{ "u7o.snd",		0x10000, 0x6947be8a, 2 | BRF_PRG | BRF_ESS }, //  2 M6809 Code
+
+	{ "abak_b01.s02",	0x80000, 0xbc805680, 3 | BRF_GRA },           //  3 Tilemap 0&1 Tiles & Characters (Encrypted)
+	{ "abak_b01.s13",	0x80000, 0x350effcd, 3 | BRF_GRA },           //  4
+	{ "abak_b23.s02",	0x80000, 0x91abdc21, 3 | BRF_GRA },           //  5
+	{ "abak_b23.s13",	0x80000, 0x80eb50fe, 3 | BRF_GRA },           //  6
+
+	{ "bbak_b01.s02",	0x80000, 0x611be9a6, 4 | BRF_GRA },           //  7 Tilemap 2&3 Tiles (Encrypted)
+	{ "bbak_b01.s13",	0x80000, 0x097e0604, 4 | BRF_GRA },           //  8
+	{ "bbak_b23.s02",	0x80000, 0x3836531a, 4 | BRF_GRA },           //  9
+	{ "bbak_b23.s13",	0x80000, 0x1210485a, 4 | BRF_GRA },           // 10
+
+	{ "ob1_c0.b0",		0x80000, 0x053fecca, 5 | BRF_GRA },           // 11 Sprites bank 0
+	{ "ob1_c1.b0",		0x80000, 0xe183e6bc, 5 | BRF_GRA },           // 12
+	{ "ob1_c2.b0",		0x80000, 0x1314f828, 5 | BRF_GRA },           // 13
+	{ "ob1_c3.b0",		0x80000, 0xc63866df, 5 | BRF_GRA },           // 14
+	{ "ob1_c4.b0",		0x80000, 0xf71cdd1b, 5 | BRF_GRA },           // 15
+	{ "ob1_c0.b1",		0x80000, 0x385434b0, 5 | BRF_GRA },           // 16
+	{ "ob1_c1.b1",		0x80000, 0x0a3ec489, 5 | BRF_GRA },           // 17
+	{ "ob1_c2.b1",		0x80000, 0x52f06081, 5 | BRF_GRA },           // 18
+	{ "ob1_c3.b1",		0x80000, 0xa8a5cfbe, 5 | BRF_GRA },           // 19
+	{ "ob1_c4.b1",		0x80000, 0x09d0acd6, 5 | BRF_GRA },           // 20
+	{ "ob1_c0.b2",		0x80000, 0x946e9f59, 5 | BRF_GRA },           // 21
+	{ "ob1_c1.b2",		0x80000, 0x9f66ad54, 5 | BRF_GRA },           // 22
+	{ "ob1_c2.b2",		0x80000, 0xa8df60eb, 5 | BRF_GRA },           // 23
+	{ "ob1_c3.b2",		0x80000, 0xa1a753be, 5 | BRF_GRA },           // 24
+	{ "ob1_c4.b2",		0x80000, 0xb65b3c4b, 5 | BRF_GRA },           // 25
+	{ "ob1_c0.b3",		0x80000, 0xcbbbc696, 5 | BRF_GRA },           // 26
+	{ "ob1_c1.b3",		0x80000, 0xf7b1bdee, 5 | BRF_GRA },           // 27
+	{ "ob1_c2.b3",		0x80000, 0x97815619, 5 | BRF_GRA },           // 28
+	{ "ob1_c3.b3",		0x80000, 0xfc3ccb7a, 5 | BRF_GRA },           // 29
+	{ "ob1_c4.b3",		0x80000, 0xdfdfd0ff, 5 | BRF_GRA },           // 30
+
+	{ "ob2_c0.b0",		0x80000, 0x9080ebe4, 6 | BRF_GRA },           // 31 Sprites bank 1
+	{ "ob2_c1.b0",		0x80000, 0xc0464970, 6 | BRF_GRA },           // 32
+	{ "ob2_c2.b0",		0x80000, 0x35a2e621, 6 | BRF_GRA },           // 33
+	{ "ob2_c3.b0",		0x80000, 0x99c7cc2d, 6 | BRF_GRA },           // 34
+	{ "ob2_c0.b1",		0x80000, 0x2c2c15c9, 6 | BRF_GRA },           // 35
+	{ "ob2_c1.b1",		0x80000, 0xd2c49a14, 6 | BRF_GRA },           // 36
+	{ "ob2_c2.b1",		0x80000, 0xfbe957e8, 6 | BRF_GRA },           // 37
+	{ "ob2_c3.b1",		0x80000, 0xd7238829, 6 | BRF_GRA },           // 38
+	{ "ob2_c0.b2",		0x80000, 0xaefa1b01, 6 | BRF_GRA },           // 39
+	{ "ob2_c1.b2",		0x80000, 0x4af620ca, 6 | BRF_GRA },           // 40
+	{ "ob2_c2.b2",		0x80000, 0x8e58be07, 6 | BRF_GRA },           // 41
+	{ "ob2_c3.b2",		0x80000, 0x1b5188c5, 6 | BRF_GRA },           // 42
+	{ "ob2_c0.b3",		0x80000, 0xa2a5dafd, 6 | BRF_GRA },           // 43
+	{ "ob2_c1.b3",		0x80000, 0x6f0afd05, 6 | BRF_GRA },           // 44
+	{ "ob2_c2.b3",		0x80000, 0x90fe5f4f, 6 | BRF_GRA },           // 45
+	{ "ob2_c3.b3",		0x80000, 0xe3517e6e, 6 | BRF_GRA },           // 46
+
+	{ "u17o.snd",		0x80000, 0xb945c18d, 7 | BRF_GRA },           // 47 BSMT Samples
+	{ "u21o.snd",		0x80000, 0x10b2110c, 7 | BRF_GRA },           // 48
+	{ "u36o.snd",		0x80000, 0x3b73abe2, 7 | BRF_GRA },           // 49
+	{ "u37o.snd",		0x80000, 0x986066b5, 7 | BRF_GRA },           // 50
+
+	{ "eeprom-tattass.bin",	0x00400, 0x7140f40c, 8 | BRF_PRG | BRF_ESS }, // 51 Default Settings
+
+#if !defined ROM_VERIFY
+	{ "bsmt2000.bin",	0x02000, 0xc2a265af, 9 | BRF_PRG | BRF_ESS }, // 52 DSP Code
+#endif
+};
+
+STD_ROM_PICK(tattasso)
+STD_ROM_FN(tattasso)
+
+struct BurnDriver BurnDrvTattasso = {
+	"tattasso", "tattass", NULL, NULL, "1994",
+	"Tattoo Assassins (US prototype, Mar 14 1995, Older sound)\0", NULL, "Data East Pinball", "DECO 32",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_PREFIX_DATAEAST, GBF_VSFIGHT, 0,
+	NULL, tattassoRomInfo, tattassoRomName, NULL, NULL, NULL, NULL, TattassInputInfo, TattassDIPInfo,
 	TattassInit, DrvExit, DrvBSMTFrame, NslasherDraw, DrvScan, &DrvRecalc, 0x800,
 	320, 240, 4, 3
 };

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43648,9 +43648,9 @@ struct BurnDriver BurnDrvmd_fatfuryone = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Final Fight MD (HB, v0.82b)
+// Final Fight MD (HB, v0.83b)
 static struct BurnRomInfo md_ffightmdRomDesc[] = {
-	{ "Final Fight MD v0.82b (2025)(MXRetroDev - CFX).bin", 4063232, 0x6760ec67, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Final Fight MD v0.83b (2025)(MXRetroDev - CFX).bin", 4063232, 0xcde690d4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_ffightmd)
@@ -43658,7 +43658,7 @@ STD_ROM_FN(md_ffightmd)
 
 struct BurnDriver BurnDrvmd_ffightmd = {
 	"md_ffightmd", NULL, NULL, NULL, "2025",
-	"Final Fight MD (HB, v0.82b)\0", "Patreon release", "MXRetroDev - CFX", "Genesis / Mega Drive",
+	"Final Fight MD (HB, v0.83b)\0", "Patreon release", "MXRetroDev - CFX", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_ffightmdRomInfo, md_ffightmdRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43923,17 +43923,18 @@ struct BurnDriver BurnDrvmd_sor2ffc20 = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// The Punisher in the Streets of Rage (Hack, v1.26)
+// The Punisher in the Streets of Rage (Hack, v1.28)
+// https://www.romhacking.net/hacks/4564/
 static struct BurnRomInfo md_punisorRomDesc[] = {
-	{ "The Punisher in the Streets of Rage v1.26 (2020)(DhaLauHoo).bin", 2915136, 0x59942a92, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "The Punisher in the Streets of Rage v1.28 (2023)(DhaLauHoo).bin", 2915136, 0xab42b435, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_punisor)
 STD_ROM_FN(md_punisor)
 
 struct BurnDriver BurnDrvmd_punisor = {
-	"md_punisor", "md_sor2", NULL, NULL, "2020",
-	"The Punisher in the Streets of Rage (Hack, v1.26)\0", NULL, "hack (Dha Lau Hoo)", "Sega Megadrive",
+	"md_punisor", "md_sor2", NULL, NULL, "2023",
+	"The Punisher in the Streets of Rage (Hack, v1.28)\0", NULL, "hack (Dha Lau Hoo)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_punisorRomInfo, md_punisorRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43593,10 +43593,10 @@ struct BurnDriver BurnDrvmd_yazzie = {
 // Extra Roms - Homebrews, Hacks and more
 // --------------------------------------
 
-// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.9)
+// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.9A)
 // https://ssf2tnf.blogspot.com/p/releases.html
 static struct BurnRomInfo md_bssf2gqRomDesc[] = {
-	{ "Bishoujo Super Street Fighter II - Glamor Queen v2.9 (2025)(Yoni Arousement).bin", 5242880, 0x99dce0db, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v2.9A (2025)(Yoni Arousement).bin", 5242880, 0xccd8889f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bssf2gq)
@@ -43604,7 +43604,7 @@ STD_ROM_FN(md_bssf2gq)
 
 struct BurnDriver BurnDrvmd_bssf2gq = {
 	"md_bssf2gq", "md_ssf2", NULL, NULL, "2025",
-	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.9)\0", "NB: also applied 'NoPause' patch.", "Yoni Arousement", "Sega Megadrive",
+	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.9A)\0", "NB: also applied 'NoPause' patch.", "Yoni Arousement", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43607,6 +43607,10 @@ struct BurnDriver BurnDrvmd_yazzie = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// ----------
+// Extra Roms
+// ----------
+
 // Telethugs (HB)
 static struct BurnRomInfo md_telehugsRomDesc[] = {
 	{ "Telethugs (2020)(Menos Playstation).bin", 1310720, 0x742da49f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
@@ -43889,7 +43893,7 @@ struct BurnDriver BurnDrvmd_sonic3kbrc = {
 	"md_sonic3kbrc", "md_sks3", NULL, NULL, "2021",
 	"Sonic 3 & Knuckles - Batlle Race (Hack By Natsumi)\0", NULL, "Natsumi", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 1, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_sonic3kbrcRomInfo, md_sonic3kbrcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43604,6 +43604,24 @@ struct BurnDriver BurnDrvmd_telehugs = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Fatal Fury One (v1.5)
+static struct BurnRomInfo md_fatfuryoneRomDesc[] = {
+	{ "Fatal Fury One (v.1.5) (Brazil) (Unl).bin", 4194304, 0x004a99e1, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_fatfuryone)
+STD_ROM_FN(md_fatfuryone)
+
+struct BurnDriver BurnDrvmd_fatfuryone = {
+	"md_fatfuryone", NULL, NULL, NULL, "2022",
+	"Fatal Fury One (HB)\0", NULL, "Master Linkuei / GameDevBoss", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_fatfuryoneRomInfo, md_fatfuryoneRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // Fight for Vengeance (HB)
 static struct BurnRomInfo md_fightvengRomDesc[] = {
 	{ "Fight for Vengeance (2021)(PSCD Games).bin", 4194304, 0x7db61291, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -42730,10 +42730,10 @@ struct BurnDriver BurnDrvmd_s3comp = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic the Hedgehog 3 Complete - Emerald Safari (Hack)
+// Sonic the Hedgehog 3 Complete - Emerald Safari (Hack, v1.0a)
 // https://www.romhacking.net/hacks/8242/
 static struct BurnRomInfo md_s3compesRomDesc[] = {
-	{ "Sonic 3 Complete - Emerald Safari (2023)(BillyTime! Games).bin", 3932160, 0xaf6088b1, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Sonic 3 Complete - Emerald Safari v1.0a (2023)(BillyTime! Games).bin", 3932160, 0x9df80fed, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_s3compes)
@@ -42741,7 +42741,7 @@ STD_ROM_FN(md_s3compes)
 
 struct BurnDriver BurnDrvmd_s3compes = {
 	"md_s3compes", "md_sks3", NULL, NULL, "2023",
-	"Sonic the Hedgehog 3 Complete - Emerald Safari (Hack)\0", NULL, "BillyTime! Games", "Sega Megadrive",
+	"Sonic the Hedgehog 3 Complete - Emerald Safari (Hack, v1.0a)\0", NULL, "BillyTime! Games", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_FRAM, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_s3compesRomInfo, md_s3compesRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43593,10 +43593,10 @@ struct BurnDriver BurnDrvmd_yazzie = {
 // Extra Roms - Homebrews, Hacks and more
 // --------------------------------------
 
-// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.7)
+// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.9)
 // https://ssf2tnf.blogspot.com/p/releases.html
 static struct BurnRomInfo md_bssf2gqRomDesc[] = {
-	{ "Bishoujo Super Street Fighter II - Glamor Queen v2.7 (2025)(Yoni Arousement).bin", 5242880, 0x2df919cc, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v2.9 (2025)(Yoni Arousement).bin", 5242880, 0x99dce0db, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bssf2gq)
@@ -43604,7 +43604,7 @@ STD_ROM_FN(md_bssf2gq)
 
 struct BurnDriver BurnDrvmd_bssf2gq = {
 	"md_bssf2gq", "md_ssf2", NULL, NULL, "2025",
-	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.7)\0", "NB: also applied 'NoPause' patch.", "Yoni Arousement", "Sega Megadrive",
+	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.9)\0", "NB: also applied 'NoPause' patch.", "Yoni Arousement", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43658,6 +43658,24 @@ struct BurnDriver BurnDrvmd_fightvengt = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Real Bout Fatal Fury Genesis Lite (HB, v1.5.1)
+static struct BurnRomInfo md_rbffgenltRomDesc[] = {
+	{ "Real Bout Fatal Fury Genesis Lite v1.5.1 (2024)(Rheo Gamer).bin", 5242880, 0x45d73398, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_rbffgenlt)
+STD_ROM_FN(md_rbffgenlt)
+
+struct BurnDriver BurnDrvmd_rbffgenlt = {
+	"md_rbffgenlt", NULL, NULL, NULL, "2024",
+	"Real Bout Fatal Fury Genesis Lite (HB, v1.5.1)\0", NULL, "Rheo Gamer", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2 | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_SRAM, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_rbffgenltRomInfo, md_rbffgenltRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // TMNT - The Streets of Rage Project (U) (V0.3.24) (Hack By savok)
 static struct BurnRomInfo md_tmnttsorpRomDesc[] = {
 	{ "TMNT The Streets of Rage Project.bin", 0x2B0A46, 0x48FCB065, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43794,11 +43794,11 @@ struct BurnDriver BurnDrvmd_sonic3kbrc = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)
+// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.7)
 // https://romhackplaza.org/romhacks/bishoujo-super-street-fighter-ii-glamor-queen-genesis/
 
 static struct BurnRomInfo md_bssf2gqRomDesc[] = {
-	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.6 (2024)(Yoni Arousement).bin", 5242880, 0xf8aab4d4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.7 (2024)(Yoni Arousement).bin", 5242880, 0x6ed2530f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bssf2gq)
@@ -43806,7 +43806,7 @@ STD_ROM_FN(md_bssf2gq)
 
 struct BurnDriver BurnDrvmd_bssf2gq = {
 	"md_bssf2gq", "md_ssf2", NULL, NULL, "2024",
-	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)\0", NULL, "hack (Yoni Arousement)", "Sega Megadrive",
+	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.7)\0", NULL, "hack (Yoni Arousement)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43604,9 +43604,9 @@ struct BurnDriver BurnDrvmd_telehugs = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Fatal Fury One (v1.5)
+// Fatal Fury One (Brazil) (Unl) (HB, v1.5)
 static struct BurnRomInfo md_fatfuryoneRomDesc[] = {
-	{ "Fatal Fury One (v.1.5) (Brazil) (Unl).bin", 4194304, 0x004a99e1, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Fatal Fury One v.1.5 (Brazil, Unl)(2022)(Master Linkuei, GameDevBoss).bin", 4194304, 0x004a99e1, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_fatfuryone)
@@ -43614,7 +43614,7 @@ STD_ROM_FN(md_fatfuryone)
 
 struct BurnDriver BurnDrvmd_fatfuryone = {
 	"md_fatfuryone", NULL, NULL, NULL, "2022",
-	"Fatal Fury One (HB)\0", NULL, "Master Linkuei / GameDevBoss", "Sega Megadrive",
+	"Fatal Fury One (Brazil) (Unl) (HB, v1.5)\0", NULL, "Master Linkuei, GameDevBoss", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_fatfuryoneRomInfo, md_fatfuryoneRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43794,6 +43794,26 @@ struct BurnDriver BurnDrvmd_sonic3kbrc = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)
+// https://romhackplaza.org/romhacks/bishoujo-super-street-fighter-ii-glamor-queen-genesis/
+
+static struct BurnRomInfo md_bssf2gqRomDesc[] = {
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.6 (2024)(Yoni Arousement).bin", 5242880, 0x87a6c750, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_bssf2gq)
+STD_ROM_FN(md_bssf2gq)
+
+struct BurnDriver BurnDrvmd_bssf2gq = {
+	"md_bssf2gq", "md_ssf2", NULL, NULL, "2024",
+	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)\0", NULL, "hack (Yoni Arousement)", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // Streets of Rage - Killer Difficulty by gsaurus
 // https://www.romhacking.net/hacks/1341/
 static struct BurnRomInfo md_sorkillerRomDesc[] = {

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -42730,25 +42730,6 @@ struct BurnDriver BurnDrvmd_s3comp = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic the Hedgehog 3 Complete - Emerald Safari (Hack, v1.0a)
-// https://www.romhacking.net/hacks/8242/
-static struct BurnRomInfo md_s3compesRomDesc[] = {
-	{ "Sonic 3 Complete - Emerald Safari v1.0a (2023)(BillyTime! Games).bin", 3932160, 0x9df80fed, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_s3compes)
-STD_ROM_FN(md_s3compes)
-
-struct BurnDriver BurnDrvmd_s3compes = {
-	"md_s3compes", "md_sks3", NULL, NULL, "2023",
-	"Sonic the Hedgehog 3 Complete - Emerald Safari (Hack, v1.0a)\0", NULL, "BillyTime! Games", "Sega Megadrive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_FRAM, GBF_PLATFORM, FBF_SONIC,
-	MegadriveGetZipName, md_s3compesRomInfo, md_s3compesRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
 // Mortal Kombat Revelations v1.0 Hack By Smoke
 static struct BurnRomInfo md_mkrRomDesc[] = {
 	{ "Mortal Kombat Revelations (Hack Ver. 1.0 By Smoke).bin", 0x987A70, 0x318B81F2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
@@ -43701,6 +43682,45 @@ struct BurnDriver BurnDrvmd_fightvengt = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Insane Pain (HB)
+
+static struct BurnRomInfo md_insanepainRomDesc[] = {
+	{ "Insane Pain (2022)(Blast Process Games).bin", 4194304, 0xe5487539, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_insanepain)
+STD_ROM_FN(md_insanepain)
+
+struct BurnDriver BurnDrvmd_insanepain = {
+	"md_insanepain", NULL, NULL, NULL, "2022",
+	"Insane Pain (HB)\0", NULL, "Blast Process Games", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_insanepainRomInfo, md_insanepainRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Kunio no Nekketsu School Fighters Beta (HB, Beta v.05b)
+// https://usagiru-orochi.itch.io/kunio-no-nekketsu-school-fighters
+
+static struct BurnRomInfo md_knnsfRomDesc[] = {
+	{ "Kunio no Nekketsu School Fighters Beta v.05b (2023)(UsagiRu).bin", 4194304, 0x1054a215, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_knnsf)
+STD_ROM_FN(md_knnsf)
+
+struct BurnDriver BurnDrvmd_knnsf = {
+	"md_knnsf", NULL, NULL, NULL, "2024",
+	"Kunio no Nekketsu School Fighters (HB, Beta v.05b)\0", NULL, "UsagiRu", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_knnsfRomInfo, md_knnsfRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // PuzzuL SwaP (HB, Final Beta)
 static struct BurnRomInfo md_puzzulswapRomDesc[] = {
 	{ "PuzzuL SwaP - final beta (2023)(GF64).bin", 288320, 0x22072371, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
@@ -43731,8 +43751,64 @@ struct BurnDriver BurnDrvmd_rbffgenlt = {
 	"md_rbffgenlt", NULL, NULL, NULL, "2024",
 	"Real Bout Fatal Fury Genesis Lite (HB, v1.5.1)\0", NULL, "Rheo Gamer", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2 | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_SRAM, GBF_VSFIGHT, 0,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_rbffgenltRomInfo, md_rbffgenltRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Sonic the Hedgehog 3 Complete - Emerald Safari (Hack, v1.0a)
+// https://www.romhacking.net/hacks/8242/
+static struct BurnRomInfo md_s3compesRomDesc[] = {
+	{ "Sonic 3 Complete - Emerald Safari v1.0a (2024)(BillyTime! Games).bin", 3932160, 0x9df80fed, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_s3compes)
+STD_ROM_FN(md_s3compes)
+
+struct BurnDriver BurnDrvmd_s3compes = {
+	"md_s3compes", "md_sks3", NULL, NULL, "2024",
+	"Sonic the Hedgehog 3 Complete - Emerald Safari (Hack, v1.0a)\0", NULL, "BillyTime! Games", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_FRAM, GBF_PLATFORM, FBF_SONIC,
+	MegadriveGetZipName, md_s3compesRomInfo, md_s3compesRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Sonic 3 & Knuckles - Batlle Race (Hack By Natsumi)
+static struct BurnRomInfo md_sonic3kbrcRomDesc[] = {
+	{ "Sonic3KnucklesBatlleRace.bin", 0x3FB496, 0xE23DD7C2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_sonic3kbrc)
+STD_ROM_FN(md_sonic3kbrc)
+
+struct BurnDriver BurnDrvmd_sonic3kbrc = {
+	"md_sonic3kbrc", "md_sks3", NULL, NULL, "2021",
+	"Sonic 3 & Knuckles - Batlle Race (Hack By Natsumi)\0", NULL, "Natsumi", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
+	MegadriveGetZipName, md_sonic3kbrcRomInfo, md_sonic3kbrcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Streets of Rage - Killer Difficulty by gsaurus
+// https://www.romhacking.net/hacks/1341/
+static struct BurnRomInfo md_sorkillerRomDesc[] = {
+	{ "Streets of Rage - Killer Difficulty (2012)(gsaurus).bin", 0x080000, 0x86eed3d6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_sorkiller)
+STD_ROM_FN(md_sorkiller)
+
+struct BurnDriver BurnDrvmd_sorkiller = {
+	"md_sorkiller", "md_sor", NULL, NULL, "2012",
+	"Streets of Rage (Killer Difficulty v0.9, hack)\0", NULL, "gsaurus", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_16BIT_ONLY, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
+	MegadriveGetZipName, md_sorkillerRomInfo, md_sorkillerRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
@@ -43881,24 +43957,6 @@ struct BurnDriver BurnDrvmd_sor2wof1k = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic 3 & Knuckles - Batlle Race (Hack By Natsumi)
-static struct BurnRomInfo md_sonic3kbrcRomDesc[] = {
-	{ "Sonic3KnucklesBatlleRace.bin", 0x3FB496, 0xE23DD7C2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_sonic3kbrc)
-STD_ROM_FN(md_sonic3kbrc)
-
-struct BurnDriver BurnDrvmd_sonic3kbrc = {
-	"md_sonic3kbrc", "md_sks3", NULL, NULL, "2021",
-	"Sonic 3 & Knuckles - Batlle Race (Hack By Natsumi)\0", NULL, "Natsumi", "Sega Megadrive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
-	MegadriveGetZipName, md_sonic3kbrcRomInfo, md_sonic3kbrcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
 // Teenage Mutant Ninja Turtles: Shredder's Re-Revenge (GlobalHack, v1.01)
 // https://www.romhacking.net/hacks/7399/
 static struct BurnRomInfo md_tmntsrrRomDesc[] = {
@@ -43992,44 +44050,6 @@ struct BurnDriver BurnDrvmd_sor2xmor = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2xmorRomInfo, md_sor2xmorRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
-// Streets of Rage - Killer Difficulty by gsaurus
-// https://www.romhacking.net/hacks/1341/
-static struct BurnRomInfo md_sorkillerRomDesc[] = {
-	{ "Streets of Rage - Killer Difficulty (2012)(gsaurus).bin", 0x080000, 0x86eed3d6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_sorkiller)
-STD_ROM_FN(md_sorkiller)
-
-struct BurnDriver BurnDrvmd_sorkiller = {
-	"md_sorkiller", "md_sor", NULL, NULL, "2012",
-	"Streets of Rage (Killer Difficulty v0.9, hack)\0", NULL, "gsaurus", "Sega Megadrive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_16BIT_ONLY, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
-	MegadriveGetZipName, md_sorkillerRomInfo, md_sorkillerRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
-// Insane Pain (HB)
-
-static struct BurnRomInfo md_insanepainRomDesc[] = {
-	{ "Insane Pain (2022)(Blast Process Games).bin", 4194304, 0xe5487539, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_insanepain)
-STD_ROM_FN(md_insanepain)
-
-struct BurnDriver BurnDrvmd_insanepain = {
-	"md_insanepain", NULL, NULL, NULL, "2022",
-	"Insane Pain (HB)\0", NULL, "Blast Process Games", "Sega Megadrive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
-	MegadriveGetZipName, md_insanepainRomInfo, md_insanepainRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43802,9 +43802,10 @@ struct BurnDriver BurnDrvmd_sonic3kbrc = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-//Teenage Mutant Ninja Turtles - Shredder's Re-Revenge (USA) (Hack By Savok/PPI-Akiko)
+// Teenage Mutant Ninja Turtles: Shredder's Re-Revenge (GlobalHack, v1.01)
+// https://www.romhacking.net/hacks/7399/
 static struct BurnRomInfo md_tmntsrrRomDesc[] = {
-	{ "TMNT_Shredders_ReRevenge.md", 0x3E007C, 0x6720CC8A, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Teenage Mutant Ninja Turtles - Shredder's Re-Revenge GlobHack (2022)(savok).bin", 4063356, 0x6720cc8a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_tmntsrr)
@@ -43812,7 +43813,7 @@ STD_ROM_FN(md_tmntsrr)
 
 struct BurnDriver BurnDrvmd_tmntsrr = {
 	"md_tmntsrr", "md_sor2", NULL, NULL, "1992",
-	"Teenage Mutant Ninja Turtles - Shredder's Re-Revenge (USA) (Hack By Savok/PPI-Akiko)\0", NULL, "2022 Savok", "Sega Megadrive",
+	"Teenage Mutant Ninja Turtles: Shredder's Re-Revenge (GlobalHack, v1.01)\0", NULL, "hack (savok)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_tmntsrrRomInfo, md_tmntsrrRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -42802,9 +42802,9 @@ struct BurnDriver BurnDrvmd_umk3h = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Ultimate Mortal Kombat 3 OSC (Hack, v29a) - 2024-03-02
+// Ultimate Mortal Kombat 3 OSC (Hack, v30a) - 2024-06-28
 static struct BurnRomInfo md_umk3oscRomDesc[] = {
-	{ "Ultimate Mortal Kombat 3 OSC v29a (2024)(Bonus).bin", 5458706, 0x263cb534, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Ultimate Mortal Kombat 3 OSC v30a (2024)(Bonus).bin", 5459522, 0x486535ed, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_umk3osc)
@@ -42812,7 +42812,7 @@ STD_ROM_FN(md_umk3osc)
 
 struct BurnDriver BurnDrvmd_umk3osc = {
 	"md_umk3osc", "md_umk3", NULL, NULL, "2024",
-	"Ultimate Mortal Kombat 3 OSC (Hack, v29a)\0", NULL, "Bonus", "Sega Megadrive",
+	"Ultimate Mortal Kombat 3 OSC (Hack, v30a)\0", NULL, "Bonus", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_umk3oscRomInfo, md_umk3oscRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43551,18 +43551,18 @@ struct BurnDriver BurnDrvmd_wmargin = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Cave Story Doukutsu (HB, en, v0.8.0)
+// Cave Story Doukutsu (HB, English v0.8.0)
 // https://github.com/andwn/cave-story-md/releases/tag/v0.8.0
 static struct BurnRomInfo md_cavestoryRomDesc[] = {
-	{ "Cave Story Doukutsu (HB, en, v0.8.0).bin", 4194304, 0xd476a108, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Cave Story Doukutsu v0.8.0 (EN)(2022)(Studio Pixel).bin", 4194304, 0xd476a108, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_cavestory)
 STD_ROM_FN(md_cavestory)
 
 struct BurnDriver BurnDrvmd_cavestory = {
-	"md_cavestory", NULL, NULL, NULL, "2022-02",
-	"Cave Story Doukutsu (HB, English, v0.8.0)\0", NULL, "Studio Pixel", "Sega Megadrive",
+	"md_cavestory", NULL, NULL, NULL, "2022",
+	"Cave Story Doukutsu (HB, English v0.8.0)\0", NULL, "Studio Pixel", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 1, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM | GBF_MISC, 0,
 	MegadriveGetZipName, md_cavestoryRomInfo, md_cavestoryRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -714,7 +714,7 @@ struct BurnDriver BurnDrvmd_artalive = {
 
 // Streets of Rage (Euro, USA, Rev. A) ~ Bare Knuckle - Ikari no Tetsuken (Jpn, Rev. A)
 static struct BurnRomInfo md_sorRomDesc[] = {
-	{ "mpr-14125a.ic1", 0x080000, 0x4052e845, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage (Euro, USA, Rev A)(1991)(Sega).bin", 524288, 0x4052e845, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor)
@@ -732,7 +732,7 @@ struct BurnDriver BurnDrvmd_sor = {
 
 // Streets of Rage (Euro, USA) ~ Bare Knuckle - Ikari no Tetsuken (Jpn)
 static struct BurnRomInfo md_soraRomDesc[] = {
-	{ "mpr-14125.ic1", 0x080000, 0xbff227c6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage (Euro, Japan, USA)(1991)(Sega).bin", 524288, 0xbff227c6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sora)
@@ -14088,7 +14088,7 @@ struct BurnDriver BurnDrvmd_greendog = {
 
 // Grind Stormer (USA)
 static struct BurnRomInfo md_grindstRomDesc[] = {
-	{ "grind stormer (usa).bin", 0x100000, 0x7e6bef15, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Grind Stormer (USA)(1994)(Tengen).bin", 1048576, 0x7e6bef15, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_grindst)
@@ -14106,7 +14106,7 @@ struct BurnDriver BurnDrvmd_grindst = {
 
 // V-Five (Jpn)
 static struct BurnRomInfo md_vfiveRomDesc[] = {
-	{ "v-v (jpn).bin", 0x100000, 0xad9d0ec0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "V-Five (Japan)(1994)(Tengen).bin", 1048576, 0xad9d0ec0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_vfive)
@@ -14124,7 +14124,7 @@ struct BurnDriver BurnDrvmd_vfive = {
 
 // Growl (USA)
 static struct BurnRomInfo md_growlRomDesc[] = {
-	{ "growl (usa).bin", 0x080000, 0xf60ef143, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Growl (USA)(1991)(Taito).bin", 524288, 0xf60ef143, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_growl)
@@ -14142,7 +14142,7 @@ struct BurnDriver BurnDrvmd_growl = {
 
 // Runark (Jpn, Kor)
 static struct BurnRomInfo md_runarkRomDesc[] = {
-	{ "runark (jpn, kor).bin", 0x080000, 0x0894d8fb, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Runark (Japan, Korea)(1991)(Taito).bin", 524288, 0x0894d8fb, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_runark)
@@ -30851,7 +30851,7 @@ struct BurnDriver BurnDrvmd_sracer = {
 
 // Street Smart (Jpn, USA)
 static struct BurnRomInfo md_ssmartRomDesc[] = {
-	{ "street smart (usa, jpn).bin", 0x080000, 0xb1dedfad, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Street Smart (Japan, USA)(1991)(Treco).bin", 524288, 0xb1dedfad, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_ssmart)
@@ -30869,7 +30869,7 @@ struct BurnDriver BurnDrvmd_ssmart = {
 
 // Streets of Rage II (Euro) ~ Bare Knuckle II - Shitou e no Chingonka (Jpn)
 static struct BurnRomInfo md_sor2RomDesc[] = {
-	{ "mpr-15309.bin", 0x200000, 0x42e3efdc, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage II (Euro, Japan)(1993)(Sega).bin", 2097152, 0x42e3efdc, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2)
@@ -30887,7 +30887,7 @@ struct BurnDriver BurnDrvmd_sor2 = {
 
 // Streets of Rage 2 (USA)
 static struct BurnRomInfo md_sor2uRomDesc[] = {
-	{ "streets of rage 2 (usa).bin", 0x200000, 0xe01fa526, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 2 (USA)(1992)(Sega).bin", 2097152, 0xe01fa526, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2u)
@@ -30903,17 +30903,17 @@ struct BurnDriver BurnDrvmd_sor2u = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 (USA) Syndicate Wars 2016 Hack by Gsaurus
+// Streets of Rage 2 (USA) Syndicate Wars 2016 (Hack)
 static struct BurnRomInfo md_sor2uswRomDesc[] = {
-	{ "sor2 sw.bin", 0x31b5ce, 0xb49b4a9b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 2 (USA) Syndicate Wars 2016 (2016)(Gsaurus).bin", 3257806, 0xb49b4a9b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2usw)
 STD_ROM_FN(md_sor2usw)
 
 struct BurnDriver BurnDrvmd_sor2usw = {
-	"md_sor2usw", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 (USA) Syndicate Wars 2016 (Hack, April 30, 2016)\0", NULL, "2016 Gsaurus", "Sega Megadrive",
+	"md_sor2usw", "md_sor2", NULL, NULL, "2016",
+	"Streets of Rage 2 (USA) Syndicate Wars 2016 (Hack)\0", NULL, "hack (Gsaurus)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2uswRomInfo, md_sor2uswRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -30924,7 +30924,7 @@ struct BurnDriver BurnDrvmd_sor2usw = {
 // Streets of Rage 2 Puyo Wars (Hack)
 // Source : https://www.romhacking.net/hacks/3063/
 static struct BurnRomInfo md_sor2upwRomDesc[] = {
-	{ "sor2u_pw.md", 0x3ce448, 0xf618ec40, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 2 Puyo Wars (2014)(Candra Software).bin", 3990600, 0xf618ec40, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2upw)
@@ -30932,7 +30932,7 @@ STD_ROM_FN(md_sor2upw)
 
 struct BurnDriver BurnDrvmd_sor2upw = {
 	"md_sor2upw", "md_sor2", NULL, NULL, "2014",
-	"Streets of Rage 2 Puyo Wars (Hack)\0", NULL, "Candra Software", "Sega Megadrive",
+	"Streets of Rage 2 Puyo Wars (Hack)\0", NULL, "hack (Candra Software)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2upwRomInfo, md_sor2upwRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -30942,7 +30942,7 @@ struct BurnDriver BurnDrvmd_sor2upw = {
 
 // Bare Knuckle II (Jpn, Prototype)
 static struct BurnRomInfo md_bk2pRomDesc[] = {
-	{ "bare knuckle ii (jpn) (beta).bin", 0x130000, 0x0cf2acbe, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bare Knuckle II (Japan, Proto)(1992)(Sega).bin", 1245184, 0x0cf2acbe, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bk2p)
@@ -30960,7 +30960,7 @@ struct BurnDriver BurnDrvmd_bk2p = {
 
 // Streets of Rage 3 (Euro)
 static struct BurnRomInfo md_sor3RomDesc[] = {
-	{ "mpr-16834+mpr-16835.bin", 0x300000, 0x3b78135f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Euro)(1994)(Sega).bin", 3145728, 0x3b78135f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3)
@@ -30978,7 +30978,7 @@ struct BurnDriver BurnDrvmd_sor3 = {
 
 // Streets of Rage 3 (Kor)
 static struct BurnRomInfo md_sor3kRomDesc[] = {
-	{ "streets of rage 3 (kor).bin", 0x300000, 0x90ef991e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Korea)(1994)(Sega).bin", 3145728, 0x90ef991e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3k)
@@ -30994,18 +30994,18 @@ struct BurnDriver BurnDrvmd_sor3k = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Bare Knuckle 3 Project (World) (Hack by Gsaurus, April 25, 2019)
+// Bare Knuckle 3 Project (World) (Hack)
 // Source: https://steamcommunity.com/sharedfiles/filedetails/?id=675893652
 static struct BurnRomInfo md_sor3bk3pRomDesc[] = {
-	{ "The Bare Knuckle 3 Project.bin", 0x3b3eca, 0xaa7e7937, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bare Knuckle 3 Project (World)(2019)(Gsaurus).bin", 3882698, 0xaa7e7937, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3bk3p)
 STD_ROM_FN(md_sor3bk3p)
 
 struct BurnDriver BurnDrvmd_sor3bk3p = {
-	"md_sor3bk3p", "md_sor3", NULL, NULL, "1994",
-	"Bare Knuckle 3 Project (World) (Hack, 2019)\0", NULL, "2019 Gsaurus", "Sega Megadrive",
+	"md_sor3bk3p", "md_sor3", NULL, NULL, "2019",
+	"Bare Knuckle 3 Project (World) (Hack)\0", NULL, "hack (Gsaurus)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor3bk3pRomInfo, md_sor3bk3pRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -31013,18 +31013,18 @@ struct BurnDriver BurnDrvmd_sor3bk3p = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 3 Project (USA) (Hack by Gsaurus, version 0.3)
+// Streets of Rage 3 Project (USA) (Hack, v0.3)
 // Source: https://www.romhacking.net/hacks/1346/
 static struct BurnRomInfo md_sor3proRomDesc[] = {
-	{ "The Streets of Rage 3 Project.bin", 0x3011C4, 0x06b93815, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 Project (USA, v0.3)(2018)(Gsaurus).bin", 3150276, 0x06b93815, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3pro)
 STD_ROM_FN(md_sor3pro)
 
 struct BurnDriver BurnDrvmd_sor3pro = {
-	"md_sor3pro", "md_sor3", NULL, NULL, "1994",
-	"Streets of Rage 3 Project (USA) (Hack, 0.3)\0", NULL, "2018 Gsaurus", "Sega Megadrive",
+	"md_sor3pro", "md_sor3", NULL, NULL, "2018",
+	"Streets of Rage 3 Project (USA) (Hack, 0.3)\0", NULL, "hack (Gsaurus)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor3proRomInfo, md_sor3proRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -31032,18 +31032,18 @@ struct BurnDriver BurnDrvmd_sor3pro = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Bare Knuckle III Project (Japan) (Hack by Gsaurus, version 0.3)
+// Bare Knuckle III Project (Japan) (Hack, v0.3)
 // Source: https://www.romhacking.net/hacks/1346/
 static struct BurnRomInfo md_bk3proRomDesc[] = {
-	{ "The Bare Knuckle III Project.bin", 0x3014C4, 0x5aa71c8b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bare Knuckle III Project (Japan, v0.3)(2018)(Gsaurus).bin", 3151044, 0x5aa71c8b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bk3pro)
 STD_ROM_FN(md_bk3pro)
 
 struct BurnDriver BurnDrvmd_bk3pro = {
-	"md_bk3pro", "md_sor3", NULL, NULL, "1994",
-	"Bare Knuckle III Project (Japan) (Hack, 0.3)\0", NULL, "2018 Gsaurus", "Sega Megadrive",
+	"md_bk3pro", "md_sor3", NULL, NULL, "2018",
+	"Bare Knuckle III Project (Japan) (Hack, v0.3)\0", NULL, "hack (Gsaurus)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_bk3proRomInfo, md_bk3proRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -31053,7 +31053,7 @@ struct BurnDriver BurnDrvmd_bk3pro = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940412)
 static struct BurnRomInfo md_sor3p5RomDesc[] = {
-	{ "streets of rage 3 (euro) (prototype - apr 12, 1994).bin", 0x300000, 0xa17ce5ab, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Euro, Prototype, 19940412)(Sega).bin", 3145728, 0xa17ce5ab, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p5)
@@ -31071,7 +31071,7 @@ struct BurnDriver BurnDrvmd_sor3p5 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940413)
 static struct BurnRomInfo md_sor3p4RomDesc[] = {
-	{ "streets of rage 3 (euro) (prototype - apr 13, 1994).bin", 0x300000, 0x164e42ae, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Euro, Prototype, 19940413)(Sega).bin", 3145728, 0x164e42ae, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p4)
@@ -31089,7 +31089,7 @@ struct BurnDriver BurnDrvmd_sor3p4 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940415)
 static struct BurnRomInfo md_sor3p3RomDesc[] = {
-	{ "streets of rage 3 (euro) (prototype - apr 15, 1994).bin", 0x300000, 0xc64f1e6b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Euro, Prototype, 19940415)(Sega).bin", 3145728, 0xc64f1e6b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p3)
@@ -31107,7 +31107,7 @@ struct BurnDriver BurnDrvmd_sor3p3 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940420)
 static struct BurnRomInfo md_sor3p2RomDesc[] = {
-	{ "streets of rage 3 (euro) (prototype - apr 20, 1994).bin", 0x300000, 0x6ae4bd8e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Euro, Prototype, 19940420)(Sega).bin", 3145728, 0x6ae4bd8e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p2)
@@ -31125,7 +31125,7 @@ struct BurnDriver BurnDrvmd_sor3p2 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940425)
 static struct BurnRomInfo md_sor3p1RomDesc[] = {
-	{ "streets of rage 3 (euro) (prototype - apr 25, 1994).bin", 0x300000, 0x7033878a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Euro, Prototype, 19940425)(Sega).bin", 3145728, 0x7033878a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p1)
@@ -31143,7 +31143,7 @@ struct BurnDriver BurnDrvmd_sor3p1 = {
 
 // Streets of Rage 3 (Prototype, 19940401)
 static struct BurnRomInfo md_sor3up06RomDesc[] = {
-	{ "streets of rage 3 (prototype - apr 01, 1994).bin", 0x300000, 0x797e75b7, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940401)(Sega).bin", 3145728, 0x797e75b7, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up06)
@@ -31161,7 +31161,7 @@ struct BurnDriver BurnDrvmd_sor3up06 = {
 
 // Streets of Rage 3 (Prototype, 19940404)
 static struct BurnRomInfo md_sor3up05RomDesc[] = {
-	{ "streets of rage 3 (prototype - apr 04, 1994).bin", 0x300000, 0x6b968f13, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940404)(Sega).bin", 3145728, 0x6b968f13, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up05)
@@ -31179,7 +31179,7 @@ struct BurnDriver BurnDrvmd_sor3up05 = {
 
 // Streets of Rage 3 (Prototype, 19940408)
 static struct BurnRomInfo md_sor3up04RomDesc[] = {
-	{ "streets of rage 3 (prototype - apr 08, 1994).bin", 0x300000, 0xd4ba76c2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940408)(Sega).bin", 3145728, 0xd4ba76c2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up04)
@@ -31197,7 +31197,7 @@ struct BurnDriver BurnDrvmd_sor3up04 = {
 
 // Streets of Rage 3 (Prototype, 19940411)
 static struct BurnRomInfo md_sor3up03RomDesc[] = {
-	{ "streets of rage 3 (prototype - apr 11, 1994).bin", 0x300000, 0xfa5e5a82, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940411)(Sega).bin", 3145728, 0xfa5e5a82, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up03)
@@ -31215,7 +31215,7 @@ struct BurnDriver BurnDrvmd_sor3up03 = {
 
 // Streets of Rage 3 (Prototype, 19940412)
 static struct BurnRomInfo md_sor3up02RomDesc[] = {
-	{ "streets of rage 3 (prototype - apr 12, 1994).bin", 0x300000, 0x3f52cb72, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940412)(Sega).bin", 3145728, 0x3f52cb72, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up02)
@@ -31233,7 +31233,7 @@ struct BurnDriver BurnDrvmd_sor3up02 = {
 
 // Streets of Rage 3 (Prototype, 19940413)
 static struct BurnRomInfo md_sor3up01RomDesc[] = {
-	{ "streets of rage 3 (prototype - apr 13, 1994).bin", 0x300000, 0x6b675807, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940413)(Sega).bin", 3145728, 0x6b675807, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up01)
@@ -31251,7 +31251,7 @@ struct BurnDriver BurnDrvmd_sor3up01 = {
 
 // Streets of Rage 3 (Prototype, 19940308)
 static struct BurnRomInfo md_sor3up10RomDesc[] = {
-	{ "streets of rage 3 (prototype - mar 08, 1994).bin", 0x300000, 0xea50b551, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940308)(Sega).bin", 3145728, 0xea50b551, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up10)
@@ -31269,7 +31269,7 @@ struct BurnDriver BurnDrvmd_sor3up10 = {
 
 // Streets of Rage 3 (Prototype, 19940317)
 static struct BurnRomInfo md_sor3up09RomDesc[] = {
-	{ "streets of rage 3 (prototype - mar 17, 1994).bin", 0x300000, 0x39ad962b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940317)(Sega).bin", 3145728, 0x39ad962b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up09)
@@ -31287,7 +31287,7 @@ struct BurnDriver BurnDrvmd_sor3up09 = {
 
 // Streets of Rage 3 (Prototype, 19940318)
 static struct BurnRomInfo md_sor3up08RomDesc[] = {
-	{ "streets of rage 3 (prototype - mar 18, 1994).bin", 0x300000, 0x60142484, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940318)(Sega).bin", 3145728, 0x60142484, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up08)
@@ -31305,7 +31305,7 @@ struct BurnDriver BurnDrvmd_sor3up08 = {
 
 // Streets of Rage 3 (Prototype, 19940328)
 static struct BurnRomInfo md_sor3up07RomDesc[] = {
-	{ "streets of rage 3 (prototype - mar 28, 1994).bin", 0x300000, 0x8757f797, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (Prototype, 19940328)(Sega).bin", 3145728, 0x8757f797, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up07)
@@ -31323,7 +31323,7 @@ struct BurnDriver BurnDrvmd_sor3up07 = {
 
 // Streets of Rage 3 (USA)
 static struct BurnRomInfo md_sor3uRomDesc[] = {
-	{ "streets of rage 3 (usa).bin", 0x300000, 0xd5bb15d9, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 3 (USA)(1994)(Sega).bin", 3145728, 0xd5bb15d9, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3u)
@@ -31341,7 +31341,7 @@ struct BurnDriver BurnDrvmd_sor3u = {
 
 // Bare Knuckle III (Jpn)
 static struct BurnRomInfo md_bk3RomDesc[] = {
-	{ "bare knuckle iii (jpn).bin", 0x300000, 0x5d09236f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bare Knuckle III (Japan)(1994)(Sega).bin", 3145728, 0x5d09236f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bk3)
@@ -31359,7 +31359,7 @@ struct BurnDriver BurnDrvmd_bk3 = {
 
 // Bare Knuckle III (Jpn, Prototype)
 static struct BurnRomInfo md_bk3pRomDesc[] = {
-	{ "bare knuckle iii (jpn) (beta).bin", 0x300000, 0xe7ff99db, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bare Knuckle III (Japan, Proto)(1994)(Sega).bin", 3145728, 0xe7ff99db, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bk3p)
@@ -31377,7 +31377,7 @@ struct BurnDriver BurnDrvmd_bk3p = {
 
 // Strider (Euro, USA)
 static struct BurnRomInfo md_striderRomDesc[] = {
-	{ "mpr-13487.bin", 0x100000, 0xb9d099a4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Strider (Euro, USA)(1990)(Sega).bin", 1048576, 0xb9d099a4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_strider)
@@ -31395,7 +31395,7 @@ struct BurnDriver BurnDrvmd_strider = {
 
 // Strider Hiryuu (Jpn, Kor)
 static struct BurnRomInfo md_striderjRomDesc[] = {
-	{ "strider hiryuu (jpn, kor).bin", 0x100000, 0x859173f2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Strider Hiryuu (Japan, Korea)(1990)(Sega).bin", 1048576, 0x859173f2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_striderj)
@@ -31413,7 +31413,7 @@ struct BurnDriver BurnDrvmd_striderj = {
 
 // Strider II (Euro)
 static struct BurnRomInfo md_strider2RomDesc[] = {
-	{ "strider ii (euro).bin", 0x100000, 0xe85e5270, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Strider II (Euro)(1990)(U.S. Gold).bin", 1048576, 0xe85e5270, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_strider2)
@@ -31431,7 +31431,7 @@ struct BurnDriver BurnDrvmd_strider2 = {
 
 // Strider Returns - Journey from Darkness (USA)
 static struct BurnRomInfo md_strider2uRomDesc[] = {
-	{ "strider returns - journey from darkness (usa).bin", 0x100000, 0x42589b79, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Strider Returns - Journey from Darkness (USA)(1990)(U.S. Gold).bin", 1048576, 0x42589b79, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_strider2u)
@@ -42603,9 +42603,9 @@ struct BurnDriver BurnDrvmd_sonictlw = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// South Island Adventure V0.3 (Hack By Hivebrain)
+// South Island Adventure (Hack, v0.3)
 static struct BurnRomInfo md_southiaRomDesc[] = {
-	{ "South Island Adventure V0.3.bin", 0x8CED0, 0xCED56180, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "South Island Adventure v0.3 (2004)(Hivebrain).bin", 577232, 0xced56180, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_southia)
@@ -42613,7 +42613,7 @@ STD_ROM_FN(md_southia)
 
 struct BurnDriver BurnDrvmd_southia = {
 	"md_southia", "md_sonic", NULL, NULL, "2004",
-	"South Island Adventure (Hack, V0.3)\0", NULL, "2004 Hivebrain", "Sega Megadrive",
+	"South Island Adventure (Hack, V0.3)\0", NULL, "hack (Hivebrain)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_southiaRomInfo, md_southiaRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -42621,9 +42621,9 @@ struct BurnDriver BurnDrvmd_southia = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Knuckles the Echidna in Sonic the Hedgehog (Hack By Stealth)
+// Knuckles the Echidna in Sonic the Hedgehog (Hack)
 static struct BurnRomInfo md_ktesonicRomDesc[] = {
-	{ "ktesonic.bin", 0x9FF80, 0x57A6DDB3, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Knuckles the Echidna in Sonic the Hedgehog (2005)(Stealth).bin", 655232, 0x57a6ddb3, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_ktesonic)
@@ -42631,7 +42631,7 @@ STD_ROM_FN(md_ktesonic)
 
 struct BurnDriver BurnDrvmd_ktesonic = {
 	"md_ktesonic", "md_sonic", NULL, NULL, "2005",
-	"Knuckles the Echidna in Sonic the Hedgehog (Hack)\0", NULL, "2005 Stealth", "Sega Megadrive",
+	"Knuckles the Echidna in Sonic the Hedgehog (Hack)\0", NULL, "hack (Stealth)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_ktesonicRomInfo, md_ktesonicRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -42639,9 +42639,9 @@ struct BurnDriver BurnDrvmd_ktesonic = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic Boom (Hack By snkenjoi,iojnekns)
+// Sonic Boom (Hack)
 static struct BurnRomInfo md_sboomRomDesc[] = {
-	{ "Sonic Boom (Hack).bin", 0x16FDA0, 0xAA903C50, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Sonic Boom (2009)(snkenjoi, iojnekns).bin", 1506720, 0xaa903c50, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sboom)
@@ -42649,7 +42649,7 @@ STD_ROM_FN(md_sboom)
 
 struct BurnDriver BurnDrvmd_sboom = {
 	"md_sboom", "md_sonic2", NULL, NULL, "2009",
-	"Sonic Boom (Hack)\0", NULL, "2009 snkenjoi, iojnekns", "Sega Megadrive",
+	"Sonic Boom (Hack)\0", NULL, "hack (snkenjoi, iojnekns)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_sboomRomInfo, md_sboomRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -42657,9 +42657,9 @@ struct BurnDriver BurnDrvmd_sboom = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic 2 SMTP (Hack By SMTP)
+// Sonic 2 SMTP (Hack)
 static struct BurnRomInfo md_s2smtpRomDesc[] = {
-	{ "s2smtp_v0.5.bin", 0x1fa42a, 0xd116fef0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Sonic 2 SMTP v0.5 (2007)(SMTP).bin", 2073642, 0xd116fef0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_s2smtp)
@@ -42667,7 +42667,7 @@ STD_ROM_FN(md_s2smtp)
 
 struct BurnDriver BurnDrvmd_s2smtp = {
 	"md_s2smtp", "md_sonic2", NULL, NULL, "2007",
-	"Sonic 2 SMTP (Hack, v0.5)\0", NULL, "2007 SMTP", "Sega Megadrive",
+	"Sonic 2 SMTP (Hack, v0.5)\0", NULL, "hack (SMTP)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_s2smtpRomInfo, md_s2smtpRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -42675,9 +42675,9 @@ struct BurnDriver BurnDrvmd_s2smtp = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic 2 Delta (Hack By Esrael)
+// Sonic 2 Delta (Hack, v0.25a)
 static struct BurnRomInfo md_s2deltaRomDesc[] = {
-	{ "Sonic2Cl.bin", 0x200000, 0x74abb0af, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Sonic 2 Delta v0.25a (2015)(Esrael Neto).bin", 2097152, 0x74abb0af, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_s2delta)
@@ -42685,7 +42685,7 @@ STD_ROM_FN(md_s2delta)
 
 struct BurnDriver BurnDrvmd_s2delta = {
 	"md_s2delta", "md_sonic2", NULL, NULL, "2015",
-	"Sonic 2 Delta (Hack, v0.25a)\0", NULL, "2015 Esrael", "Sega Megadrive",
+	"Sonic 2 Delta (Hack, v0.25a)\0", NULL, "hack (Esrael)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_s2deltaRomInfo, md_s2deltaRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -42693,9 +42693,9 @@ struct BurnDriver BurnDrvmd_s2delta = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic 3 & Knuckles - The Challenges (Hack By ColinC10)
+// Sonic 3 & Knuckles - The Challenges
 static struct BurnRomInfo md_s3ktcRomDesc[] = {
-	{ "S3K_TheChallenges.bin", 0x400000, 0x04179928, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Sonic 3 & Knuckles - The Challenges (2009)(ColinC10).bin", 4194304, 0x04179928, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_s3ktc)
@@ -42703,7 +42703,7 @@ STD_ROM_FN(md_s3ktc)
 
 struct BurnDriver BurnDrvmd_s3ktc = {
 	"md_s3ktc", "md_sks3", NULL, NULL, "2009",
-	"Sonic 3 & Knuckles - The Challenges (Hack)\0", "Lock-On Technology", "2009 ColinC10", "Sega Megadrive",
+	"Sonic 3 & Knuckles - The Challenges (Hack)\0", "Lock-On Technology", "hack (ColinC10)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_s3ktcRomInfo, md_s3ktcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -42711,9 +42711,10 @@ struct BurnDriver BurnDrvmd_s3ktc = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic the Hedgehog 3 Complete (Hack By Tiddles)
+// Sonic the Hedgehog 3 Complete (Hack)
+// https://www.romhacking.net/hacks/1056/
 static struct BurnRomInfo md_s3compRomDesc[] = {
-	{ "S3Complete.bin", 0x3C0000, 0x2BD564B1, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Sonic the Hedgehog 3 Complete (2013)(Tiddles).bin", 3932160, 0x2bd564b1, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_s3comp)
@@ -42721,7 +42722,7 @@ STD_ROM_FN(md_s3comp)
 
 struct BurnDriver BurnDrvmd_s3comp = {
 	"md_s3comp", "md_sks3", NULL, NULL, "2013",
-	"Sonic the Hedgehog 3 Complete (World, Hack)\0", NULL, "2013 Tiddles", "Sega Megadrive",
+	"Sonic the Hedgehog 3 Complete (World, Hack)\0", NULL, "hack (Tiddles)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_s3compRomInfo, md_s3compRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43588,31 +43588,33 @@ struct BurnDriver BurnDrvmd_yazzie = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// ----------
-// Extra Roms
-// ----------
 
-// Telethugs (HB)
-static struct BurnRomInfo md_telehugsRomDesc[] = {
-	{ "Telethugs (2020)(Menos Playstation).bin", 1310720, 0x742da49f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+// --------------------------------------
+// Extra Roms - Homebrews, Hacks and more
+// --------------------------------------
+
+// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.7)
+// https://ssf2tnf.blogspot.com/p/releases.html
+static struct BurnRomInfo md_bssf2gqRomDesc[] = {
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v2.7 (2025)(Yoni Arousement).bin", 5242880, 0x2df919cc, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
-STD_ROM_PICK(md_telehugs)
-STD_ROM_FN(md_telehugs)
+STD_ROM_PICK(md_bssf2gq)
+STD_ROM_FN(md_bssf2gq)
 
-struct BurnDriver BurnDrvmd_telehugs = {
-	"md_telehugs", NULL, NULL, NULL, "2020",
-	"Telethugs (HB)\0", NULL, "Menos Playstation", "Sega Megadrive",
+struct BurnDriver BurnDrvmd_bssf2gq = {
+	"md_bssf2gq", "md_ssf2", NULL, NULL, "2025",
+	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v2.7)\0", "NB: also applied 'NoPause' patch.", "Yoni Arousement", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_RUNGUN, 0,
-	MegadriveGetZipName, md_telehugsRomInfo, md_telehugsRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
 // Doroppu (HB)
 static struct BurnRomInfo md_doroppuRomDesc[] = {
-	{ "doroppu (2015)(repixel8).bin", 127420, 0xbb1eaeda, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Doroppu (2015)(repixel8).bin", 127420, 0xbb1eaeda, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_doroppu)
@@ -43642,6 +43644,24 @@ struct BurnDriver BurnDrvmd_fatfuryone = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_fatfuryoneRomInfo, md_fatfuryoneRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Final Fight MD (HB, v0.82b)
+static struct BurnRomInfo md_ffightmdRomDesc[] = {
+	{ "Final Fight MD v0.82b (2025)(MXRetroDev - CFX).bin", 4063232, 0x6760ec67, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_ffightmd)
+STD_ROM_FN(md_ffightmd)
+
+struct BurnDriver BurnDrvmd_ffightmd = {
+	"md_ffightmd", NULL, NULL, NULL, "2025",
+	"Final Fight MD (HB, v0.82b)\0", "Patreon release", "MXRetroDev - CFX", "Genesis / Mega Drive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
+	MegadriveGetZipName, md_ffightmdRomInfo, md_ffightmdRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
@@ -43757,6 +43777,24 @@ struct BurnDriver BurnDrvmd_rbffgenlt = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Shaolin Carcará (HB, Rev. 1)
+static struct BurnRomInfo md_shaolincarcaraRomDesc[] = {
+	{ "Shaolin Carcara (Rev 1)(2020-22)(Manganga Team).bin", 2359296, 0x7bd5e34f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_shaolincarcara)
+STD_ROM_FN(md_shaolincarcara)
+
+struct BurnDriver BurnDrvmd_shaolincarcara = {
+	"md_shaolincarcara", NULL, NULL, NULL, "2020-22",
+	"Shaolin Carcar\u00e1 (HB, Rev. 1)\0", NULL, "Manganga Team", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
+	MegadriveGetZipName, md_shaolincarcaraRomInfo, md_shaolincarcaraRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // Sonic the Hedgehog 3 Complete - Emerald Safari (Hack, v1.0a)
 // https://www.romhacking.net/hacks/8242/
 static struct BurnRomInfo md_s3compesRomDesc[] = {
@@ -43776,9 +43814,9 @@ struct BurnDriver BurnDrvmd_s3compes = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic 3 & Knuckles - Batlle Race (Hack By Natsumi)
+// Sonic 3 & Knuckles - Batlle Race (Hack)
 static struct BurnRomInfo md_sonic3kbrcRomDesc[] = {
-	{ "Sonic3KnucklesBatlleRace.bin", 0x3FB496, 0xE23DD7C2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Sonic 3 & Knuckles - Batlle Race (2021)(Natsumi).bin", 4174998, 0xe23dd7c2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sonic3kbrc)
@@ -43786,7 +43824,7 @@ STD_ROM_FN(md_sonic3kbrc)
 
 struct BurnDriver BurnDrvmd_sonic3kbrc = {
 	"md_sonic3kbrc", "md_sks3", NULL, NULL, "2021",
-	"Sonic 3 & Knuckles - Batlle Race (Hack By Natsumi)\0", NULL, "Natsumi", "Sega Megadrive",
+	"Sonic 3 & Knuckles - Batlle Race (Hack)\0", NULL, "hack (Natsumi)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_sonic3kbrcRomInfo, md_sonic3kbrcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43794,30 +43832,10 @@ struct BurnDriver BurnDrvmd_sonic3kbrc = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.7)
-// https://romhackplaza.org/romhacks/bishoujo-super-street-fighter-ii-glamor-queen-genesis/
-
-static struct BurnRomInfo md_bssf2gqRomDesc[] = {
-	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.7 (2024)(Yoni Arousement).bin", 5242880, 0x6ed2530f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_bssf2gq)
-STD_ROM_FN(md_bssf2gq)
-
-struct BurnDriver BurnDrvmd_bssf2gq = {
-	"md_bssf2gq", "md_ssf2", NULL, NULL, "2024",
-	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.7)\0", NULL, "hack (Yoni Arousement)", "Sega Megadrive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
-	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
-// Streets of Rage - Killer Difficulty by gsaurus
+// Streets of Rage - Killer Difficulty (Hack, v0.9)
 // https://www.romhacking.net/hacks/1341/
 static struct BurnRomInfo md_sorkillerRomDesc[] = {
-	{ "Streets of Rage - Killer Difficulty (2012)(gsaurus).bin", 0x080000, 0x86eed3d6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage - Killer Difficulty v0.9 (2012)(gsaurus).bin", 524288, 0x86eed3d6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sorkiller)
@@ -43825,7 +43843,7 @@ STD_ROM_FN(md_sorkiller)
 
 struct BurnDriver BurnDrvmd_sorkiller = {
 	"md_sorkiller", "md_sor", NULL, NULL, "2012",
-	"Streets of Rage (Killer Difficulty v0.9, hack)\0", NULL, "gsaurus", "Sega Megadrive",
+	"Streets of Rage - Killer Difficulty (Hack, v0.9)\0", NULL, "hack (gsaurus)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_16BIT_ONLY, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sorkillerRomInfo, md_sorkillerRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43833,17 +43851,17 @@ struct BurnDriver BurnDrvmd_sorkiller = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// TMNT - The Streets of Rage Project (U) (V0.3.24) (Hack By savok)
+// TMNT - The Streets of Rage Project (Hack, v0.3.24)
 static struct BurnRomInfo md_tmnttsorpRomDesc[] = {
-	{ "TMNT The Streets of Rage Project.bin", 0x2B0A46, 0x48FCB065, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "TMNT - The Streets of Rage Project v0.3.24 (2021)(savok).bin", 2820678, 0x48fcb065, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_tmnttsorp)
 STD_ROM_FN(md_tmnttsorp)
 
 struct BurnDriver BurnDrvmd_tmnttsorp = {
-	"md_tmnttsorp", "md_sor2", NULL, NULL, "1992",
-	"TMNT - The Streets of Rage Project (U) (V0.3.24) (Hack By savok)\0", NULL, "2021 Savok", "Sega Megadrive",
+	"md_tmnttsorp", "md_sor2", NULL, NULL, "2021",
+	"TMNT - The Streets of Rage Project (Hack, v0.3.24)\0", NULL, "hack (savok)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_tmnttsorpRomInfo, md_tmnttsorpRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43851,17 +43869,17 @@ struct BurnDriver BurnDrvmd_tmnttsorp = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 - Extreme Mania (U) (V1.0) (Hack By eskayelle)
+// Streets of Rage 2 - Extreme Mania (Hack, v1.0)
 static struct BurnRomInfo md_sor2emRomDesc[] = {
-	{ "Streets of Rage 2 Extreme Mania.bin", 0x200000, 0x3AE95E2F, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 2 - Extreme Mania v1.0 (2019)(eskayelle).bin", 2097152, 0x3ae95e2f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2em)
 STD_ROM_FN(md_sor2em)
 
 struct BurnDriver BurnDrvmd_sor2em = {
-	"md_sor2em", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 - Extreme Mania (U) (V1.0) (Hack By eskayelle)\0", NULL, "2019 eskayelle", "Sega Megadrive",
+	"md_sor2em", "md_sor2", NULL, NULL, "2019",
+	"Streets of Rage 2 - Extreme Mania (Hack, v1.0)\0", NULL, "hack (eskayelle)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2emRomInfo, md_sor2emRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43869,17 +43887,17 @@ struct BurnDriver BurnDrvmd_sor2em = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 - Captain Commando Edition (U) (Hack By Metal64)
+// Streets of Rage 2 - Captain Commando Edition (Hack)
 static struct BurnRomInfo md_sor2ccRomDesc[] = {
-	{ "Streets of Rage 2 Captain Commando Edition.gen", 0x296056, 0xDC455FD8, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 2 - Captain Commando Edition (2019)(Metal64).bin", 2711638, 0xdc455fd8, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2cc)
 STD_ROM_FN(md_sor2cc)
 
 struct BurnDriver BurnDrvmd_sor2cc = {
-	"md_sor2cc", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 - Captain Commando Edition (U) (Hack By Metal64)\0", NULL, "2019 Metal64", "Sega Megadrive",
+	"md_sor2cc", "md_sor2", NULL, NULL, "2019",
+	"Streets of Rage 2 - Captain Commando Edition (Hack)\0", NULL, "hack (Metal64)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2ccRomInfo, md_sor2ccRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43887,17 +43905,17 @@ struct BurnDriver BurnDrvmd_sor2cc = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 - Final Fight Crossover 2020 (V1.30) (Hack By DhaLauHoo)
+// Streets of Rage 2 - Final Fight Crossover 2019-2020 (Hack, v1.30)
 static struct BurnRomInfo md_sor2ffc20RomDesc[] = {
-	{ "Streets of Rage 2 Final Fight Crossover 2020.bin", 0x2B7F92, 0x8BD9E3E2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "SoR2 - Final Fight Crossover 2019-2020 v1.30 (2020)(DhaLauHoo).bin", 2850706, 0x8bd9e3e2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2ffc20)
 STD_ROM_FN(md_sor2ffc20)
 
 struct BurnDriver BurnDrvmd_sor2ffc20 = {
-	"md_sor2ffc20", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 - Final Fight Crossover 2020 (V1.30) (Hack By DhaLauHoo)\0", NULL, "2020 DhaLauHoo", "Sega Megadrive",
+	"md_sor2ffc20", "md_sor2", NULL, NULL, "2020",
+	"SoR2 - Final Fight Crossover 2019-2020 (Hack, v1.30)\0", NULL, "hack (Dha Lau Hoo)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2ffc20RomInfo, md_sor2ffc20RomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43905,17 +43923,17 @@ struct BurnDriver BurnDrvmd_sor2ffc20 = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// The Punisher in the Streets of Rage (V1.26) (Hack By DhaLauHoo)
+// The Punisher in the Streets of Rage (Hack, v1.26)
 static struct BurnRomInfo md_punisorRomDesc[] = {
-	{ "The Punisher in the Streets of Rage.bin", 0x2C7B40, 0x59942A92, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "The Punisher in the Streets of Rage v1.26 (2020)(DhaLauHoo).bin", 2915136, 0x59942a92, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_punisor)
 STD_ROM_FN(md_punisor)
 
 struct BurnDriver BurnDrvmd_punisor = {
-	"md_punisor", "md_sor2", NULL, NULL, "1992",
-	"The Punisher in the Streets of Rage (V1.26) (Hack By DhaLauHoo)\0", NULL, "2020 DhaLauHoo", "Sega Megadrive",
+	"md_punisor", "md_sor2", NULL, NULL, "2020",
+	"The Punisher in the Streets of Rage (Hack, v1.26)\0", NULL, "hack (Dha Lau Hoo)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_punisorRomInfo, md_punisorRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43923,17 +43941,17 @@ struct BurnDriver BurnDrvmd_punisor = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 - The World Warrior (USA) (V1.10) (Hack By DhaLauHoo)
+// Streets of Rage 2 - The World Warrior (Hack, v1.10)
 static struct BurnRomInfo md_sor2twwRomDesc[] = {
-	{ "Streets of Rage 2 The World Warrior.bin", 0x2B50F0, 0xBA50B490, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 2 - The World Warrior v1.10 (2020)(DhaLauHoo).bin", 2838768, 0xba50b490, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2tww)
 STD_ROM_FN(md_sor2tww)
 
 struct BurnDriver BurnDrvmd_sor2tww = {
-	"md_sor2tww", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 - The World Warrior (USA) (V1.10) (Hack By DhaLauHoo)\0", NULL, "2020 DhaLauHoo", "Sega Megadrive",
+	"md_sor2tww", "md_sor2", NULL, NULL, "2020",
+	"Streets of Rage 2 - The World Warrior (Hack, v1.10)\0", NULL, "hack (Dha Lau Hoo)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2twwRomInfo, md_sor2twwRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43941,17 +43959,17 @@ struct BurnDriver BurnDrvmd_sor2tww = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 - The New Challengers (USA) (V1.26) (SOR2 Hack By DhaLauHoo)
+// Streets of Rage 2 - The New Challengers (Hack, v1.26)
 static struct BurnRomInfo md_sor2tnchaRomDesc[] = {
-	{ "Sor2TheNewChallengers.gen", 0x2B5C30, 0xA3D20794, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Streets of Rage 2 - The New Challengers v1.26 (2020)(DhaLauHoo).bin", 2841648, 0xa3d20794, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2tncha)
 STD_ROM_FN(md_sor2tncha)
 
 struct BurnDriver BurnDrvmd_sor2tncha = {
-	"md_sor2tncha", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 - The New Challengers (USA) (V1.26) (SOR2 Hack By DhaLauHoo)\0", NULL, "2020 DhaLauHoo", "Sega Megadrive",
+	"md_sor2tncha", "md_sor2", NULL, NULL, "2020",
+	"Streets of Rage 2 - The New Challengers (Hack, v1.26)\0", NULL, "hack (Dha Lau Hoo)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2tnchaRomInfo, md_sor2tnchaRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43959,17 +43977,17 @@ struct BurnDriver BurnDrvmd_sor2tncha = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 - Warriors of Fate 1000 Mans KO (V1.33) (Hack By DhaLauHoo)
+// SoR2 - Warriors of Fate - 1000 men edition (Hack, v1.33)
 static struct BurnRomInfo md_sor2wof1kRomDesc[] = {
-	{ "Sor2 Warriors of Fate 1kMansKO.bin", 0x275810, 0xA170282A, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "SoR2 - Warriors of Fate - 1000 men edition v1.33 (2020)(DhaLauHoo).bin", 2578448, 0xa170282a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2wof1k)
 STD_ROM_FN(md_sor2wof1k)
 
 struct BurnDriver BurnDrvmd_sor2wof1k = {
-	"md_sor2wof1k", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 - Warriors of Fate 1000 Mans KO (V1.33) (Hack By DhaLauHoo)\0", NULL, "2020 DhaLauHoo", "Sega Megadrive",
+	"md_sor2wof1k", "md_sor2", NULL, NULL, "2020",
+	"SoR2 - Warriors of Fate - 1000 men edition (Hack, v1.33)\0", NULL, "hack (Dha Lau Hoo)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2wof1kRomInfo, md_sor2wof1kRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -43996,17 +44014,17 @@ struct BurnDriver BurnDrvmd_tmntsrr = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Streets of Rage 2 - The Ninja Warriors Once Again (V.02905) (Hack By Savok)
+// SoR2 - The Ninja Warriors Once Again (Hack, v02905)
 static struct BurnRomInfo md_sor2tnwoaRomDesc[] = {
-	{ "Sor2TheNinjaWarriorsOnceAgain.bin", 0x2E7422, 0x1D6747E9, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "SoR2 - The Ninja Warriors Once Again v02905 (2021)(savok).bin", 3044386, 0x1d6747e9, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2tnwoa)
 STD_ROM_FN(md_sor2tnwoa)
 
 struct BurnDriver BurnDrvmd_sor2tnwoa = {
-	"md_sor2tnwoa", "md_sor2", NULL, NULL, "1992",
-	"Streets of Rage 2 - The Ninja Warriors Once Again (V.02905) (Hack By Savok)\0", NULL, "2021 Savok", "Sega Megadrive",
+	"md_sor2tnwoa", "md_sor2", NULL, NULL, "2021",
+	"SoR2 - The Ninja Warriors Once Again (Hack, v02905)\0", NULL, "hack (savok)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2tnwoaRomInfo, md_sor2tnwoaRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -44070,6 +44088,24 @@ struct BurnDriver BurnDrvmd_sor2xmor = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sor2xmorRomInfo, md_sor2xmorRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Telethugs (HB)
+static struct BurnRomInfo md_telehugsRomDesc[] = {
+	{ "Telethugs (2020)(Menos Playstation).bin", 1310720, 0x742da49f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_telehugs)
+STD_ROM_FN(md_telehugs)
+
+struct BurnDriver BurnDrvmd_telehugs = {
+	"md_telehugs", NULL, NULL, NULL, "2020",
+	"Telethugs (HB)\0", NULL, "Menos Playstation", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_RUNGUN, 0,
+	MegadriveGetZipName, md_telehugsRomInfo, md_telehugsRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43712,7 +43712,7 @@ STD_ROM_PICK(md_knnsf)
 STD_ROM_FN(md_knnsf)
 
 struct BurnDriver BurnDrvmd_knnsf = {
-	"md_knnsf", NULL, NULL, NULL, "2024",
+	"md_knnsf", NULL, NULL, NULL, "2023",
 	"Kunio no Nekketsu School Fighters (HB, Beta v.05b)\0", NULL, "UsagiRu", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43798,7 +43798,7 @@ struct BurnDriver BurnDrvmd_sonic3kbrc = {
 // https://romhackplaza.org/romhacks/bishoujo-super-street-fighter-ii-glamor-queen-genesis/
 
 static struct BurnRomInfo md_bssf2gqRomDesc[] = {
-	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.6 (2024)(Yoni Arousement).bin", 5242880, 0x87a6c750, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.6 (2024)(Yoni Arousement).bin", 5242880, 0xf8aab4d4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bssf2gq)

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -714,7 +714,7 @@ struct BurnDriver BurnDrvmd_artalive = {
 
 // Streets of Rage (Euro, USA, Rev. A) ~ Bare Knuckle - Ikari no Tetsuken (Jpn, Rev. A)
 static struct BurnRomInfo md_sorRomDesc[] = {
-	{ "Streets of Rage (Euro, USA, Rev A)(1991)(Sega).bin", 524288, 0x4052e845, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "mpr-14125a.ic1", 0x080000, 0x4052e845, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor)
@@ -732,7 +732,7 @@ struct BurnDriver BurnDrvmd_sor = {
 
 // Streets of Rage (Euro, USA) ~ Bare Knuckle - Ikari no Tetsuken (Jpn)
 static struct BurnRomInfo md_soraRomDesc[] = {
-	{ "Streets of Rage (Euro, Japan, USA)(1991)(Sega).bin", 524288, 0xbff227c6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "mpr-14125.ic1", 0x080000, 0xbff227c6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sora)
@@ -14088,7 +14088,7 @@ struct BurnDriver BurnDrvmd_greendog = {
 
 // Grind Stormer (USA)
 static struct BurnRomInfo md_grindstRomDesc[] = {
-	{ "Grind Stormer (USA)(1994)(Tengen).bin", 1048576, 0x7e6bef15, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "grind stormer (usa).bin", 0x100000, 0x7e6bef15, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_grindst)
@@ -14106,7 +14106,7 @@ struct BurnDriver BurnDrvmd_grindst = {
 
 // V-Five (Jpn)
 static struct BurnRomInfo md_vfiveRomDesc[] = {
-	{ "V-Five (Japan)(1994)(Tengen).bin", 1048576, 0xad9d0ec0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "v-v (jpn).bin", 0x100000, 0xad9d0ec0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_vfive)
@@ -14124,7 +14124,7 @@ struct BurnDriver BurnDrvmd_vfive = {
 
 // Growl (USA)
 static struct BurnRomInfo md_growlRomDesc[] = {
-	{ "Growl (USA)(1991)(Taito).bin", 524288, 0xf60ef143, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "growl (usa).bin", 0x080000, 0xf60ef143, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_growl)
@@ -14142,7 +14142,7 @@ struct BurnDriver BurnDrvmd_growl = {
 
 // Runark (Jpn, Kor)
 static struct BurnRomInfo md_runarkRomDesc[] = {
-	{ "Runark (Japan, Korea)(1991)(Taito).bin", 524288, 0x0894d8fb, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "runark (jpn, kor).bin", 0x080000, 0x0894d8fb, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_runark)
@@ -30851,7 +30851,7 @@ struct BurnDriver BurnDrvmd_sracer = {
 
 // Street Smart (Jpn, USA)
 static struct BurnRomInfo md_ssmartRomDesc[] = {
-	{ "Street Smart (Japan, USA)(1991)(Treco).bin", 524288, 0xb1dedfad, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "street smart (usa, jpn).bin", 0x080000, 0xb1dedfad, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_ssmart)
@@ -30869,7 +30869,7 @@ struct BurnDriver BurnDrvmd_ssmart = {
 
 // Streets of Rage II (Euro) ~ Bare Knuckle II - Shitou e no Chingonka (Jpn)
 static struct BurnRomInfo md_sor2RomDesc[] = {
-	{ "Streets of Rage II (Euro, Japan)(1993)(Sega).bin", 2097152, 0x42e3efdc, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "mpr-15309.bin", 0x200000, 0x42e3efdc, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2)
@@ -30887,7 +30887,7 @@ struct BurnDriver BurnDrvmd_sor2 = {
 
 // Streets of Rage 2 (USA)
 static struct BurnRomInfo md_sor2uRomDesc[] = {
-	{ "Streets of Rage 2 (USA)(1992)(Sega).bin", 2097152, 0xe01fa526, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 2 (usa).bin", 0x200000, 0xe01fa526, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor2u)
@@ -30942,7 +30942,7 @@ struct BurnDriver BurnDrvmd_sor2upw = {
 
 // Bare Knuckle II (Jpn, Prototype)
 static struct BurnRomInfo md_bk2pRomDesc[] = {
-	{ "Bare Knuckle II (Japan, Proto)(1992)(Sega).bin", 1245184, 0x0cf2acbe, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "bare knuckle ii (jpn) (beta).bin", 0x130000, 0x0cf2acbe, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bk2p)
@@ -30960,7 +30960,7 @@ struct BurnDriver BurnDrvmd_bk2p = {
 
 // Streets of Rage 3 (Euro)
 static struct BurnRomInfo md_sor3RomDesc[] = {
-	{ "Streets of Rage 3 (Euro)(1994)(Sega).bin", 3145728, 0x3b78135f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "mpr-16834+mpr-16835.bin", 0x300000, 0x3b78135f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3)
@@ -30978,7 +30978,7 @@ struct BurnDriver BurnDrvmd_sor3 = {
 
 // Streets of Rage 3 (Kor)
 static struct BurnRomInfo md_sor3kRomDesc[] = {
-	{ "Streets of Rage 3 (Korea)(1994)(Sega).bin", 3145728, 0x90ef991e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (kor).bin", 0x300000, 0x90ef991e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3k)
@@ -31053,7 +31053,7 @@ struct BurnDriver BurnDrvmd_bk3pro = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940412)
 static struct BurnRomInfo md_sor3p5RomDesc[] = {
-	{ "Streets of Rage 3 (Euro, Prototype, 19940412)(Sega).bin", 3145728, 0xa17ce5ab, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (euro) (prototype - apr 12, 1994).bin", 0x300000, 0xa17ce5ab, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p5)
@@ -31071,7 +31071,7 @@ struct BurnDriver BurnDrvmd_sor3p5 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940413)
 static struct BurnRomInfo md_sor3p4RomDesc[] = {
-	{ "Streets of Rage 3 (Euro, Prototype, 19940413)(Sega).bin", 3145728, 0x164e42ae, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (euro) (prototype - apr 13, 1994).bin", 0x300000, 0x164e42ae, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p4)
@@ -31089,7 +31089,7 @@ struct BurnDriver BurnDrvmd_sor3p4 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940415)
 static struct BurnRomInfo md_sor3p3RomDesc[] = {
-	{ "Streets of Rage 3 (Euro, Prototype, 19940415)(Sega).bin", 3145728, 0xc64f1e6b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (euro) (prototype - apr 15, 1994).bin", 0x300000, 0xc64f1e6b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p3)
@@ -31107,7 +31107,7 @@ struct BurnDriver BurnDrvmd_sor3p3 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940420)
 static struct BurnRomInfo md_sor3p2RomDesc[] = {
-	{ "Streets of Rage 3 (Euro, Prototype, 19940420)(Sega).bin", 3145728, 0x6ae4bd8e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (euro) (prototype - apr 20, 1994).bin", 0x300000, 0x6ae4bd8e, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p2)
@@ -31125,7 +31125,7 @@ struct BurnDriver BurnDrvmd_sor3p2 = {
 
 // Streets of Rage 3 (Euro, Prototype, 19940425)
 static struct BurnRomInfo md_sor3p1RomDesc[] = {
-	{ "Streets of Rage 3 (Euro, Prototype, 19940425)(Sega).bin", 3145728, 0x7033878a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (euro) (prototype - apr 25, 1994).bin", 0x300000, 0x7033878a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3p1)
@@ -31143,7 +31143,7 @@ struct BurnDriver BurnDrvmd_sor3p1 = {
 
 // Streets of Rage 3 (Prototype, 19940401)
 static struct BurnRomInfo md_sor3up06RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940401)(Sega).bin", 3145728, 0x797e75b7, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - apr 01, 1994).bin", 0x300000, 0x797e75b7, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up06)
@@ -31161,7 +31161,7 @@ struct BurnDriver BurnDrvmd_sor3up06 = {
 
 // Streets of Rage 3 (Prototype, 19940404)
 static struct BurnRomInfo md_sor3up05RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940404)(Sega).bin", 3145728, 0x6b968f13, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - apr 04, 1994).bin", 0x300000, 0x6b968f13, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up05)
@@ -31179,7 +31179,7 @@ struct BurnDriver BurnDrvmd_sor3up05 = {
 
 // Streets of Rage 3 (Prototype, 19940408)
 static struct BurnRomInfo md_sor3up04RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940408)(Sega).bin", 3145728, 0xd4ba76c2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - apr 08, 1994).bin", 0x300000, 0xd4ba76c2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up04)
@@ -31197,7 +31197,7 @@ struct BurnDriver BurnDrvmd_sor3up04 = {
 
 // Streets of Rage 3 (Prototype, 19940411)
 static struct BurnRomInfo md_sor3up03RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940411)(Sega).bin", 3145728, 0xfa5e5a82, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - apr 11, 1994).bin", 0x300000, 0xfa5e5a82, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up03)
@@ -31215,7 +31215,7 @@ struct BurnDriver BurnDrvmd_sor3up03 = {
 
 // Streets of Rage 3 (Prototype, 19940412)
 static struct BurnRomInfo md_sor3up02RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940412)(Sega).bin", 3145728, 0x3f52cb72, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - apr 12, 1994).bin", 0x300000, 0x3f52cb72, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up02)
@@ -31233,7 +31233,7 @@ struct BurnDriver BurnDrvmd_sor3up02 = {
 
 // Streets of Rage 3 (Prototype, 19940413)
 static struct BurnRomInfo md_sor3up01RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940413)(Sega).bin", 3145728, 0x6b675807, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - apr 13, 1994).bin", 0x300000, 0x6b675807, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up01)
@@ -31251,7 +31251,7 @@ struct BurnDriver BurnDrvmd_sor3up01 = {
 
 // Streets of Rage 3 (Prototype, 19940308)
 static struct BurnRomInfo md_sor3up10RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940308)(Sega).bin", 3145728, 0xea50b551, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - mar 08, 1994).bin", 0x300000, 0xea50b551, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up10)
@@ -31269,7 +31269,7 @@ struct BurnDriver BurnDrvmd_sor3up10 = {
 
 // Streets of Rage 3 (Prototype, 19940317)
 static struct BurnRomInfo md_sor3up09RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940317)(Sega).bin", 3145728, 0x39ad962b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - mar 17, 1994).bin", 0x300000, 0x39ad962b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up09)
@@ -31287,7 +31287,7 @@ struct BurnDriver BurnDrvmd_sor3up09 = {
 
 // Streets of Rage 3 (Prototype, 19940318)
 static struct BurnRomInfo md_sor3up08RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940318)(Sega).bin", 3145728, 0x60142484, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - mar 18, 1994).bin", 0x300000, 0x60142484, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up08)
@@ -31305,7 +31305,7 @@ struct BurnDriver BurnDrvmd_sor3up08 = {
 
 // Streets of Rage 3 (Prototype, 19940328)
 static struct BurnRomInfo md_sor3up07RomDesc[] = {
-	{ "Streets of Rage 3 (Prototype, 19940328)(Sega).bin", 3145728, 0x8757f797, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (prototype - mar 28, 1994).bin", 0x300000, 0x8757f797, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3up07)
@@ -31323,7 +31323,7 @@ struct BurnDriver BurnDrvmd_sor3up07 = {
 
 // Streets of Rage 3 (USA)
 static struct BurnRomInfo md_sor3uRomDesc[] = {
-	{ "Streets of Rage 3 (USA)(1994)(Sega).bin", 3145728, 0xd5bb15d9, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "streets of rage 3 (usa).bin", 0x300000, 0xd5bb15d9, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_sor3u)
@@ -31341,7 +31341,7 @@ struct BurnDriver BurnDrvmd_sor3u = {
 
 // Bare Knuckle III (Jpn)
 static struct BurnRomInfo md_bk3RomDesc[] = {
-	{ "Bare Knuckle III (Japan)(1994)(Sega).bin", 3145728, 0x5d09236f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "bare knuckle iii (jpn).bin", 0x300000, 0x5d09236f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bk3)
@@ -31359,7 +31359,7 @@ struct BurnDriver BurnDrvmd_bk3 = {
 
 // Bare Knuckle III (Jpn, Prototype)
 static struct BurnRomInfo md_bk3pRomDesc[] = {
-	{ "Bare Knuckle III (Japan, Proto)(1994)(Sega).bin", 3145728, 0xe7ff99db, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "bare knuckle iii (jpn) (beta).bin", 0x300000, 0xe7ff99db, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bk3p)
@@ -31377,7 +31377,7 @@ struct BurnDriver BurnDrvmd_bk3p = {
 
 // Strider (Euro, USA)
 static struct BurnRomInfo md_striderRomDesc[] = {
-	{ "Strider (Euro, USA)(1990)(Sega).bin", 1048576, 0xb9d099a4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "mpr-13487.bin", 0x100000, 0xb9d099a4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_strider)
@@ -31395,7 +31395,7 @@ struct BurnDriver BurnDrvmd_strider = {
 
 // Strider Hiryuu (Jpn, Kor)
 static struct BurnRomInfo md_striderjRomDesc[] = {
-	{ "Strider Hiryuu (Japan, Korea)(1990)(Sega).bin", 1048576, 0x859173f2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "strider hiryuu (jpn, kor).bin", 0x100000, 0x859173f2, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_striderj)
@@ -31413,7 +31413,7 @@ struct BurnDriver BurnDrvmd_striderj = {
 
 // Strider II (Euro)
 static struct BurnRomInfo md_strider2RomDesc[] = {
-	{ "Strider II (Euro)(1990)(U.S. Gold).bin", 1048576, 0xe85e5270, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "strider ii (euro).bin", 0x100000, 0xe85e5270, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_strider2)
@@ -31431,7 +31431,7 @@ struct BurnDriver BurnDrvmd_strider2 = {
 
 // Strider Returns - Journey from Darkness (USA)
 static struct BurnRomInfo md_strider2uRomDesc[] = {
-	{ "Strider Returns - Journey from Darkness (USA)(1990)(U.S. Gold).bin", 1048576, 0x42589b79, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "strider returns - journey from darkness (usa).bin", 0x100000, 0x42589b79, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_strider2u)
@@ -42693,7 +42693,7 @@ struct BurnDriver BurnDrvmd_s2delta = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Sonic 3 & Knuckles - The Challenges
+// Sonic 3 & Knuckles - The Challenges (Hack)
 static struct BurnRomInfo md_s3ktcRomDesc[] = {
 	{ "Sonic 3 & Knuckles - The Challenges (2009)(ColinC10).bin", 4194304, 0x04179928, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
@@ -42726,6 +42726,25 @@ struct BurnDriver BurnDrvmd_s3comp = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, FBF_SONIC,
 	MegadriveGetZipName, md_s3compRomInfo, md_s3compRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Sonic the Hedgehog 3 Complete - Emerald Safari (Hack)
+// https://www.romhacking.net/hacks/8242/
+static struct BurnRomInfo md_s3compesRomDesc[] = {
+	{ "Sonic 3 Complete - Emerald Safari (2023)(BillyTime! Games).bin", 3932160, 0xaf6088b1, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_s3compes)
+STD_ROM_FN(md_s3compes)
+
+struct BurnDriver BurnDrvmd_s3compes = {
+	"md_s3compes", "md_sks3", NULL, NULL, "2023",
+	"Sonic the Hedgehog 3 Complete - Emerald Safari (Hack)\0", NULL, "BillyTime! Games", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_FRAM, GBF_PLATFORM, FBF_SONIC,
+	MegadriveGetZipName, md_s3compesRomInfo, md_s3compesRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
@@ -43551,19 +43570,20 @@ struct BurnDriver BurnDrvmd_wmargin = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Cave Story Doukutsu (v0.5.2)
+// Cave Story Doukutsu (HB, en, v0.8.0)
+// https://github.com/andwn/cave-story-md/releases/tag/v0.8.0
 static struct BurnRomInfo md_cavestoryRomDesc[] = {
-	{ "Cave Story Doukutsu (v0.5.2).bin", 0x3e4000, 0x292080ae, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Cave Story Doukutsu (HB, en, v0.8.0).bin", 4194304, 0xd476a108, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_cavestory)
 STD_ROM_FN(md_cavestory)
 
 struct BurnDriver BurnDrvmd_cavestory = {
-	"md_cavestory", NULL, NULL, NULL, "2004",
-	"Cave Story Doukutsu (HB, v0.5.2)\0", NULL, "Studio Pixel", "Sega Megadrive",
+	"md_cavestory", NULL, NULL, NULL, "2022-02",
+	"Cave Story Doukutsu (HB, English, v0.8.0)\0", NULL, "Studio Pixel", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_MISC, 0,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 1, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM | GBF_MISC, 0,
 	MegadriveGetZipName, md_cavestoryRomInfo, md_cavestoryRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
@@ -43601,6 +43621,24 @@ struct BurnDriver BurnDrvmd_telehugs = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_RUNGUN, 0,
 	MegadriveGetZipName, md_telehugsRomInfo, md_telehugsRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Doroppu (HB)
+static struct BurnRomInfo md_doroppuRomDesc[] = {
+	{ "doroppu (2015)(repixel8).bin", 127420, 0xbb1eaeda, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_doroppu)
+STD_ROM_FN(md_doroppu)
+
+struct BurnDriver BurnDrvmd_doroppu = {
+	"md_doroppu", NULL, NULL, NULL, "2015",
+	"Doroppu (HB)\0", NULL, "Repixel8", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PUZZLE, 0,
+	MegadriveGetZipName, md_doroppuRomInfo, md_doroppuRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
@@ -43655,6 +43693,24 @@ struct BurnDriver BurnDrvmd_fightvengt = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_fightvengtRomInfo, md_fightvengtRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// PuzzuL SwaP (HB, Final Beta)
+static struct BurnRomInfo md_puzzulswapRomDesc[] = {
+	{ "PuzzuL SwaP - final beta (2023)(GF64).bin", 288320, 0x22072371, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_puzzulswap)
+STD_ROM_FN(md_puzzulswap)
+
+struct BurnDriver BurnDrvmd_puzzulswap = {
+	"md_puzzulswap", NULL, NULL, NULL, "2023",
+	"PuzzuL SwaP (HB, Final Beta)\0", NULL, "GF64", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_PUZZLE, 0,
+	MegadriveGetZipName, md_puzzulswapRomInfo, md_puzzulswapRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43830,7 +43830,7 @@ STD_ROM_PICK(md_tmntsrr)
 STD_ROM_FN(md_tmntsrr)
 
 struct BurnDriver BurnDrvmd_tmntsrr = {
-	"md_tmntsrr", "md_sor2", NULL, NULL, "1992",
+	"md_tmntsrr", "md_sor2", NULL, NULL, "2022",
 	"Teenage Mutant Ninja Turtles: Shredder's Re-Revenge (GlobalHack, v1.01)\0", NULL, "hack (savok)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21512,10 +21512,10 @@ struct BurnDriver BurnDrvmslugdqy = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-10-14
+// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-10-27
 
 static struct BurnRomInfo mslugfc2RomDesc[] = {
-	{ "201-p1fc2.p1",	0x200000, 0xb0b1d11b, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1fc2.p1",	0x200000, 0x9b991ed7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21512,10 +21512,10 @@ struct BurnDriver BurnDrvmslugdqy = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-08-31
+// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-09-26
 
 static struct BurnRomInfo mslugfc2RomDesc[] = {
-	{ "201-p1fc2.p1",	0x200000, 0x273aea46, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1fc2.p1",	0x200000, 0x42181751, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -21940,12 +21940,12 @@ struct BurnDriver BurnDrvmslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-07-11
+// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-09-23
 // Modified by ?
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
-	{ "250-p1cqi.p1",	0x100000, 0xf8f95ffa, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x400000, 0x2c36b1a5, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1cqi.p1",	0x100000, 0x2461db7a, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2cqi.ep1",	0x400000, 0xba4f6f9b, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -22202,12 +22202,12 @@ struct BurnDriver BurnDrvmslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-07-11
+// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-09-23
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0x18b951c2, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x400000, 0xd60f631d, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0xb0aa4ad0, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x400000, 0xfc25cfd7, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
@@ -22769,11 +22769,11 @@ struct BurnDriver BurnDrvmslug5esr = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-09-17
+// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-09-24
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0x6baa2e80, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0xe931d937, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 
@@ -22783,8 +22783,8 @@ static struct BurnRomInfo mslug5cqRomDesc[] = {
 	{ "268-c4d.c4",		0x800000, 0x9c00160d, 3 | BRF_GRA },            //  5
 	{ "268-c5d.c5",		0x800000, 0x38754256, 3 | BRF_GRA },            //  6
 	{ "268-c6d.c6",		0x800000, 0x59d33e9c, 3 | BRF_GRA },            //  7
-	{ "268-c7cq.c7",	0x800000, 0xe5ebe937, 3 | BRF_GRA },            //  8
-	{ "268-c8cq.c8",	0x800000, 0x43995e2b, 3 | BRF_GRA },            //  9
+	{ "268-c7cq.c7",	0x800000, 0x7638b13d, 3 | BRF_GRA },            //  8
+	{ "268-c8cq.c8",	0x800000, 0x5ee654e9, 3 | BRF_GRA },            //  9
 
 	{ "268-m1d.m1",		0x080000, 0x39f3cbba, 4 | BRF_ESS | BRF_PRG },  // 10 Z80 code
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -19290,9 +19290,9 @@ static struct BurnRomInfo mslug4dgRomDesc[] = {
 
 	{ "263-m1d.m1",     0x020000, 0xef5db532, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
 
-	{ "263-v1d.v1",     0x400000, 0x8cb5a9ef, 5 | BRF_SND },           // 10 Sound data
-	{ "263-v2d.v2",     0x400000, 0x94217b1e, 5 | BRF_SND },           // 11
-	{ "263-v3d.v3",     0x400000, 0x7616fcec, 5 | BRF_SND },           // 12
+	{ "263-v1nd.v1",    0x400000, 0x8cb5a9ef, 5 | BRF_SND },           // 10 Sound data
+	{ "263-v2nd.v2",    0x400000, 0x94217b1e, 5 | BRF_SND },           // 11
+	{ "263-v3nd.v3",    0x400000, 0x7616fcec, 5 | BRF_SND },           // 12
 	{ "263-v4dg.v4",    0x400000, 0xc5967f91, 5 | BRF_SND },           // 13
 };
 
@@ -19327,7 +19327,7 @@ static struct BurnRomInfo mslug4lwRomDesc[] = {
 
 	{ "263-m1lw.m1",    0x020000, 0x49b1453e, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
 
-	{ "263-v1d.v1",     0x400000, 0x8cb5a9ef, 5 | BRF_SND },           // 10 Sound data
+	{ "263-v1nd.v1",    0x400000, 0x8cb5a9ef, 5 | BRF_SND },           // 10 Sound data
 	{ "263-v2lw.v2",    0x400000, 0xc9572c14, 5 | BRF_SND },           // 11
 	{ "263-v3lw.v3",    0x400000, 0xe7c14624, 5 | BRF_SND },           // 12
 	{ "263-v4lw.v4",    0x800000, 0xb1e5ac70, 5 | BRF_SND },           // 13
@@ -21940,21 +21940,21 @@ struct BurnDriver BurnDrvmslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-09-23
+// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-10-15
 // Modified by ?
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
-	{ "250-p1cqi.p1",	0x100000, 0x2461db7a, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x400000, 0xba4f6f9b, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1cqi.p1",	0x100000, 0xb6ca4046, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2cqi.ep1",	0x400000, 0x05cd39da, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
 	{ "250-c1.c1",		0x800000, 0x09a52c6f, 3 | BRF_GRA },           //  3 Sprite data
 	{ "250-c2.c2",		0x800000, 0x31679821, 3 | BRF_GRA },           //  4
-	{ "250-c3.c3",		0x800000, 0xfd602019, 3 | BRF_GRA },           //  5
-	{ "250-c4.c4",		0x800000, 0x31354513, 3 | BRF_GRA },           //  6
-	{ "250-c5cqi.c5",	0x800000, 0x743cd68d, 3 | BRF_GRA },           //  7
-	{ "250-c6cqi.c6",	0x800000, 0xb1146061, 3 | BRF_GRA },           //  8
+	{ "250-c3cqi.c3",	0x800000, 0x917f95c5, 3 | BRF_GRA },           //  5
+	{ "250-c4cqi.c4",	0x800000, 0x93290f81, 3 | BRF_GRA },           //  6
+	{ "250-c5cqi.c5",	0x800000, 0xea889f46, 3 | BRF_GRA },           //  7
+	{ "250-c6cqi.c6",	0x800000, 0x480ed637, 3 | BRF_GRA },           //  8
 
 	{ "250-m1.m1",		0x020000, 0xfd42a842, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
 
@@ -22202,12 +22202,12 @@ struct BurnDriver BurnDrvmslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-09-23
+// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-10-15
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0xb0aa4ad0, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x400000, 0xfc25cfd7, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0x41becaef, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x400000, 0xe9efe7f2, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
@@ -22215,8 +22215,8 @@ static struct BurnRomInfo mslug3cqiRomDesc[] = {
 	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },           //  5
 	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },           //  6
 	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },           //  7
-	{ "256-c7cqi.c7",	0x800000, 0xa5f46605, 3 | BRF_GRA },           //  8
-	{ "256-c8cqi.c8",	0x800000, 0x03bbcf95, 3 | BRF_GRA },           //  9
+	{ "256-c7cqi.c7",	0x800000, 0xe0cbe375, 3 | BRF_GRA },           //  8
+	{ "256-c8cqi.c8",	0x800000, 0x293ee7e2, 3 | BRF_GRA },           //  9
 
 	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
 
@@ -22258,7 +22258,7 @@ static struct BurnRomInfo mslug4ammorRomDesc[] = {
 
 	{ "263-m1lw.m1",     0x020000, 0x49b1453e, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 
-	{ "263-v1d.v1",      0x400000, 0x8cb5a9ef, 5 | BRF_SND },            // 10 Sound data
+	{ "263-v1nd.v1",     0x400000, 0x8cb5a9ef, 5 | BRF_SND },            // 10 Sound data
 	{ "263-v2lw.v2",     0x400000, 0xc9572c14, 5 | BRF_SND },            // 11
 	{ "263-v3lw.v3",     0x400000, 0xe7c14624, 5 | BRF_SND },            // 12
 	{ "263-v4lw.v4",     0x800000, 0xb1e5ac70, 5 | BRF_SND },            // 13
@@ -22295,7 +22295,7 @@ static struct BurnRomInfo mslug4lwqRomDesc[] = {
 
 	{ "263-m1lw.m1",     0x020000, 0x49b1453e, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 
-	{ "263-v1d.v1",      0x400000, 0x8cb5a9ef, 5 | BRF_SND },            // 10 Sound data
+	{ "263-v1nd.v1",     0x400000, 0x8cb5a9ef, 5 | BRF_SND },            // 10 Sound data
 	{ "263-v2lw.v2",     0x400000, 0xc9572c14, 5 | BRF_SND },            // 11
 	{ "263-v3lw.v3",     0x400000, 0xe7c14624, 5 | BRF_SND },            // 12
 	{ "263-v4lw.v4",     0x800000, 0xb1e5ac70, 5 | BRF_SND },            // 13
@@ -22310,6 +22310,41 @@ struct BurnDriver BurnDrvmslug4lwq = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug4lwqRomInfo, mslug4lwqRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000,	304, 224, 4, 3
+};
+
+// Metal Slug 4 (CQI, Hack) - 2024-10-16
+// Modified by ?
+
+static struct BurnRomInfo mslug4cqiRomDesc[] = {
+	{ "263-p1cqi.p1",	0x100000, 0x41ca7c0b, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2cqi.sp2",	0x800000, 0x6fb4b241, 1 | BRF_ESS | BRF_PRG },  //  1
+	
+	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
+
+	{ "263-c1d.c1",		0x800000, 0xa75ffcde, 3 | BRF_GRA },            //  3 Sprite data
+	{ "263-c2d.c2",		0x800000, 0x5ab0d12b, 3 | BRF_GRA },            //  4
+	{ "263-c3d.c3",		0x800000, 0x61af560c, 3 | BRF_GRA },            //  5
+	{ "263-c4d.c4",		0x800000, 0xf2c544fd, 3 | BRF_GRA },            //  6
+	{ "263-c5cqi.c5",	0x800000, 0xd41f13a2, 3 | BRF_GRA },            //  7
+	{ "263-c6cqi.c6",	0x800000, 0x20dae873, 3 | BRF_GRA },            //  8
+
+	{ "263-m1d.m1",		0x020000, 0xef5db532, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
+
+	{ "263-v1d.v1",		0x800000, 0xfd6b982e, 5 | BRF_SND },            // 10 Sound data
+	{ "263-v2d.v2",		0x800000, 0x20125227, 5 | BRF_SND },            // 11
+};
+
+STDROMPICKEXT(mslug4cqi, mslug4cqi, neogeo)
+STD_ROM_FN(mslug4cqi)
+
+struct BurnDriver BurnDrvMslug4cqi = {
+	"mslug4cqi", "mslug4", "neogeo", NULL, "2024",
+	"Metal Slug 4 (CQI, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
+	NULL, mslug4cqiRomInfo, mslug4cqiRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
@@ -22769,11 +22804,11 @@ struct BurnDriver BurnDrvmslug5esr = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-09-24
+// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-10-11
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0xe931d937, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0x57de7890, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 
@@ -22783,8 +22818,8 @@ static struct BurnRomInfo mslug5cqRomDesc[] = {
 	{ "268-c4d.c4",		0x800000, 0x9c00160d, 3 | BRF_GRA },            //  5
 	{ "268-c5d.c5",		0x800000, 0x38754256, 3 | BRF_GRA },            //  6
 	{ "268-c6d.c6",		0x800000, 0x59d33e9c, 3 | BRF_GRA },            //  7
-	{ "268-c7cq.c7",	0x800000, 0x7638b13d, 3 | BRF_GRA },            //  8
-	{ "268-c8cq.c8",	0x800000, 0x5ee654e9, 3 | BRF_GRA },            //  9
+	{ "268-c7cq.c7",	0x800000, 0xd902d555, 3 | BRF_GRA },            //  8
+	{ "268-c8cq.c8",	0x800000, 0x59b7dc26, 3 | BRF_GRA },            //  9
 
 	{ "268-m1d.m1",		0x080000, 0x39f3cbba, 4 | BRF_ESS | BRF_PRG },  // 10 Z80 code
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21512,10 +21512,10 @@ struct BurnDriver BurnDrvmslugdqy = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-10-27
+// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-11-08
 
 static struct BurnRomInfo mslugfc2RomDesc[] = {
-	{ "201-p1fc2.p1",	0x200000, 0x9b991ed7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1fc2.p1",	0x200000, 0xce09f081, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -22314,7 +22314,7 @@ struct BurnDriver BurnDrvmslug4lwq = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-10-28
+// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-11-10
 // Modified by ?
 
 static struct BurnRomInfo mslug4zjRomDesc[] = {
@@ -22327,8 +22327,8 @@ static struct BurnRomInfo mslug4zjRomDesc[] = {
 	{ "263-c2d.c2",		0x800000, 0x5ab0d12b, 3 | BRF_GRA },            //  4
 	{ "263-c3d.c3",		0x800000, 0x61af560c, 3 | BRF_GRA },            //  5
 	{ "263-c4d.c4",		0x800000, 0xf2c544fd, 3 | BRF_GRA },            //  6
-	{ "263-c5zj.c5",	0x800000, 0xd41f13a2, 3 | BRF_GRA },            //  7
-	{ "263-c6zj.c6",	0x800000, 0x20dae873, 3 | BRF_GRA },            //  8
+	{ "263-c5zj.c5",	0x800000, 0x3b0347a0, 3 | BRF_GRA },            //  7
+	{ "263-c6zj.c6",	0x800000, 0xe95f5ef5, 3 | BRF_GRA },            //  8
 
 	{ "263-m1zj.m1",	0x020000, 0x2c722ea4, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -22769,11 +22769,11 @@ struct BurnDriver BurnDrvmslug5esr = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-05-02
+// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-09-17
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0x07723765, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0x6baa2e80, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -8,6 +8,8 @@
 	// #define ROM_VERIFY
 #endif
 
+UINT8 nNeo68KRAMHack = 0;
+
 static struct BurnRomInfo emptyRomDesc[] = {
 	{ "",                    0,          0, 0 },
 };
@@ -1733,15 +1735,19 @@ static void ngOverclocker(INT32 value) {
 static INT32 ngOc180taInit()
 {
 	ngOverclocker(0x01cd);
-	
 	return NeoInit();
 }
 
 static INT32 ngOc400osInit()
 {
 	ngOverclocker(0x0400);
-	
 	return NeoInit();
+}
+
+static INT32 ngOc400osRhInit()
+{
+	nNeo68KRAMHack = 1;
+	return ngOc400osInit();
 }
 
 // ----------------------------------------------------------------------------
@@ -20869,38 +20875,38 @@ struct BurnDriver BurnDrvKof2kxxx = {
 
 // The King of Fighters 2001 (Ultimate, Hack)
 // Modified by 西岐赏金猎人, 臂力哥
-// GOTVG 20250126
+// GOTVG 20250531
 
 static struct BurnRomInfo kf2k1ultRomDesc[] = {
-	{ "262-p1ult.p1",		0x100000, 0x7fb7ea52, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "262-p2ult.sp2",		0x500000, 0x6be21453, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "262-p1ult.p1",		0x100000, 0x2f5662b8, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "262-p2ult.sp2",		0x500000, 0xda344c08, 1 | BRF_ESS | BRF_PRG }, //  1
 
-	{ "262-s1ult.s1",		0x020000, 0x6bceef77, 2 | BRF_GRA },           //  2 Text layer tiles
-	
-	{ "262-c1ult.c1",		0x800000, 0xc2486ac2, 3 | BRF_GRA },           //  3 Sprite data
-	{ "262-c2ult.c2",		0x800000, 0x6614bacb, 3 | BRF_GRA },           //  4
-	{ "262-c3ult.c3",		0x800000, 0xa164f2c2, 3 | BRF_GRA },           //  5
-	{ "262-c4ult.c4",		0x800000, 0x649dc7fa, 3 | BRF_GRA },           //  6
-	{ "262-c5ult.c5",		0x800000, 0xb47e4f8d, 3 | BRF_GRA },           //  7
-	{ "262-c6ult.c6",		0x800000, 0xac5f2083, 3 | BRF_GRA },           //  8
-	{ "262-c7ult.c7",		0x800000, 0x8e0d191a, 3 | BRF_GRA },           //  9
-	{ "262-c8ult.c8",		0x800000, 0x6fea378f, 3 | BRF_GRA },           // 10
-	{ "262-c9ult.c9",		0x800000, 0xcf4b24ef, 3 | BRF_GRA },           // 11
-	{ "262-c10ult.c10",		0x800000, 0x4f20d0ff, 3 | BRF_GRA },           // 12
+	{ "262-s1ult.s1",		0x020000, 0x18a0449b, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "262-c1ult.c1",		0x800000, 0x8b531868, 3 | BRF_GRA },           //  3 Sprite data
+	{ "262-c2ult.c2",		0x800000, 0x947e7421, 3 | BRF_GRA },           //  4
+	{ "262-c3ult.c3",		0x800000, 0x26b67ec6, 3 | BRF_GRA },           //  5
+	{ "262-c4ult.c4",		0x800000, 0x7dc77374, 3 | BRF_GRA },           //  6
+	{ "262-c5ult.c5",		0x800000, 0xc08c3279, 3 | BRF_GRA },           //  7
+	{ "262-c6ult.c6",		0x800000, 0xcad8b68c, 3 | BRF_GRA },           //  8
+	{ "262-c7ult.c7",		0x800000, 0x8641cd8b, 3 | BRF_GRA },           //  9
+	{ "262-c8ult.c8",		0x800000, 0x6a21a2b8, 3 | BRF_GRA },           // 10
+	{ "262-c9ult.c9",		0x800000, 0x1a4d9823, 3 | BRF_GRA },           // 11
+	{ "262-c10ult.c10",		0x800000, 0x74fc85e9, 3 | BRF_GRA },           // 12
 	{ "265-c7d.c7",			0x800000, 0x8a5b561c, 3 | BRF_GRA },           // 13
 	{ "265-c8d.c8",			0x800000, 0xbef667a3, 3 | BRF_GRA },           // 14
-	{ "262-c13ult.c13",		0x800000, 0x19a099eb, 3 | BRF_GRA },           // 15
-	{ "262-c14ult.c14",		0x800000, 0x19a099eb, 3 | BRF_GRA },           // 16
+	{ "262-c13ult.c13",		0x800000, 0x421998ab, 3 | BRF_GRA },           // 15
+	{ "262-c14ult.c14",		0x800000, 0x9b169e23, 3 | BRF_GRA },           // 16
 
-	{ "262-m1ult.m1",		0x020000, 0xd0651ea0, 4 | BRF_ESS | BRF_PRG }, // 17 Z80 code
+	{ "262-m1ult.m1",		0x020000, 0x7027def2, 4 | BRF_ESS | BRF_PRG }, // 17 Z80 code
 
-	{ "262-v1ult-08-e0.v1",	0x400000, 0xe1496ace, 5 | BRF_SND },     // 18 Sound data
-	{ "262-v2ult-08-e0.v2",	0x400000, 0x51bd6805, 5 | BRF_SND },     // 19
-	{ "262-v3ult-08-e0.v3",	0x400000, 0x6cecc242, 5 | BRF_SND },     // 20
-	{ "262-v4ult-08-e0.v4",	0x400000, 0x81e7a417, 5 | BRF_SND },     // 21
-	{ "262-v5ult-08-e0.v5",	0x400000, 0x42423d32, 5 | BRF_SND },     // 22
-	{ "262-v6ult-08-e0.v6",	0x400000, 0x73a03cbf, 5 | BRF_SND },     // 23
-	{ "262-v7ult-08-e0.v7",	0x400000, 0x7a2d38df, 5 | BRF_SND },     // 24
+	{ "262-v1ult-08-e0.v1",	0x400000, 0x44532d73, 5 | BRF_SND },     // 18 Sound data
+	{ "262-v2ult-08-e0.v2",	0x400000, 0xc063647a, 5 | BRF_SND },     // 19
+	{ "262-v3ult-08-e0.v3",	0x400000, 0x44a334b8, 5 | BRF_SND },     // 20
+	{ "262-v4ult-08-e0.v4",	0x400000, 0x93abe5f4, 5 | BRF_SND },     // 21
+	{ "262-v5ult-08-e0.v5",	0x400000, 0x84d06192, 5 | BRF_SND },     // 22
+	{ "262-v6ult-08-e0.v6",	0x400000, 0x17bf22ae, 5 | BRF_SND },     // 23
+	{ "262-v7ult-08-e0.v7",	0x400000, 0xf7021b3c, 5 | BRF_SND },     // 24
 };
 
 STDROMPICKEXT(kf2k1ult, kf2k1ult, neogeo)
@@ -21977,10 +21983,10 @@ struct BurnDriver BurnDrvMslugfc2 = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Origins Random Item, Hack) - 2025-05-21
+// Metal Slug (Origins Random Item, Hack) - 2025-05-27
 
 static struct BurnRomInfo mslugdyf2RomDesc[] = {
-	{ "201-p1dyf2.p1",	0x200000, 0x708badd1, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1dyf2.p1",	0x200000, 0x23bf5414, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -22317,15 +22323,10 @@ static struct BurnRomInfo mslugxscRomDesc[] = {
 STDROMPICKEXT(mslugxsc, mslugxsc, neogeo)
 STD_ROM_FN(mslugxsc)
 
-static INT32 mslugxscInit() // 400% speed, AliceMSU recomendation for mslugxsc
+static INT32 mslugxscInit()
 {
- 	INT32 nRet = mslugxInit();
-	
-	if(nBurnCPUSpeedAdjust < 0x0400) {
-		nBurnCPUSpeedAdjust = 0x0400;
-	}
-	
-	return nRet;
+ 	ngOverclocker(0x400);
+	return mslugxInit();
 }
 
 struct BurnDriver BurnDrvMslugxsc = {
@@ -22374,12 +22375,12 @@ struct BurnDriver BurnDrvMslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire, Hack) - 2025-02-13
-// Modified by ?
+// Metal Slug X (Legendary Unlimited Fire v6.0, Hack) - 2025-04-03
+// Modified by AKS & SAKURA
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
-	{ "250-p1cqi.p1",	0x100000, 0xf1cd0db7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x400000, 0xab4cd88e, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1cqi.p1",	0x100000, 0xb4cc793f, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2cqi.ep1",	0x800000, 0x93534961, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -22387,26 +22388,34 @@ static struct BurnRomInfo mslugxcqiRomDesc[] = {
 	{ "250-c2.c2",		0x800000, 0x31679821, 3 | BRF_GRA },           //  4
 	{ "250-c3cqi.c3",	0x800000, 0x917f95c5, 3 | BRF_GRA },           //  5
 	{ "250-c4cqi.c4",	0x800000, 0x93290f81, 3 | BRF_GRA },           //  6
-	{ "250-c5cqi.c5",	0x800000, 0x9b14fbf2, 3 | BRF_GRA },           //  7
-	{ "250-c6cqi.c6",	0x800000, 0xe0e796d3, 3 | BRF_GRA },           //  8
+	{ "250-c5cqi.c5",	0x800000, 0xe66c6f58, 3 | BRF_GRA },           //  7
+	{ "250-c6cqi.c6",	0x800000, 0xd6406f54, 3 | BRF_GRA },           //  8
+	{ "250-c7cqi.c7",	0x800000, 0x616082e8, 3 | BRF_GRA },           //  9
+	{ "250-c8cqi.c8",	0x800000, 0xb9710e89, 3 | BRF_GRA },           // 10
 
-	{ "250-m1.m1",		0x020000, 0xfd42a842, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+	{ "250-m1.m1",		0x020000, 0xfd42a842, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "250-v1.v1",		0x400000, 0xc79ede73, 5 | BRF_SND },           // 10 Sound data
-	{ "250-v2.v2",		0x400000, 0xea9aabe1, 5 | BRF_SND },           // 11
-	{ "250-v3.v3",		0x200000, 0x2ca65102, 5 | BRF_SND },           // 12
+	{ "250-v1.v1",		0x400000, 0xc79ede73, 5 | BRF_SND },           // 12 Sound data
+	{ "250-v2.v2",		0x400000, 0xea9aabe1, 5 | BRF_SND },           // 13
+	{ "250-v3.v3",		0x200000, 0x2ca65102, 5 | BRF_SND },           // 14
 };
 
 STDROMPICKEXT(mslugxcqi, mslugxcqi, neogeo)
 STD_ROM_FN(mslugxcqi)
 
+static INT32 mslugxcqiInit()
+{
+ 	nNeo68KRAMHack = 1;
+	return mslugxscInit();
+}
+
 struct BurnDriver BurnDrvMslugxcqi = {
 	"mslugxcqi", "mslugx", "neogeo", NULL, "2025",
-	"Metal Slug X (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"Metal Slug X (Legendary Unlimited Fire v6.0, Hack)\0", NULL, "hack (AKS & SAKURA)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslugxcqiRomInfo, mslugxcqiRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	mslugxscInit, NeoExit, NeoFrame, NeoRender, mslugxScan, &NeoRecalcPalette,
+	mslugxcqiInit, NeoExit, NeoFrame, NeoRender, mslugxScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
 
@@ -22672,21 +22681,21 @@ struct BurnDriver BurnDrvMslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-12-03
-// Modified by ?
+// Metal Slug 3 (Legendary Unlimited Fire v6.0, Hack) - 2025-05-22
+// Modified by AKS
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0x458ec1b4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x400000, 0x7c5c94d6, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0x0cf334e4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x800000, 0x65c1ea54, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
 	{ "256-c3d.c3",		0x800000, 0xbfaade82, 3 | BRF_GRA },           //  4
 	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },           //  5
-	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },           //  6
-	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },           //  7
-	{ "256-c7cqi.c7",	0x800000, 0xe0cbe375, 3 | BRF_GRA },           //  8
-	{ "256-c8cqi.c8",	0x800000, 0x293ee7e2, 3 | BRF_GRA },           //  9
+	{ "256-c5cqi.c5",	0x800000, 0x0c5abf1d, 3 | BRF_GRA },           //  6
+	{ "256-c6cqi.c6",	0x800000, 0x004da62a, 3 | BRF_GRA },           //  7
+	{ "256-c7cqi.c7",	0x800000, 0x59567ee7, 3 | BRF_GRA },           //  8
+	{ "256-c8cqi.c8",	0x800000, 0x1f91351f, 3 | BRF_GRA },           //  9
 
 	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
 
@@ -22700,21 +22709,21 @@ STDROMPICKEXT(mslug3cqi, mslug3cqi, neogeo)
 STD_ROM_FN(mslug3cqi)
 
 struct BurnDriver BurnDrvMslug3cqi = {
-	"mslug3cqi", "mslug3", "neogeo", NULL, "2024",
-	"Metal Slug 3 (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"mslug3cqi", "mslug3", "neogeo", NULL, "2025",
+	"Metal Slug 3 (Legendary Unlimited Fire v6.0, Hack)\0", NULL, "hack (AKS)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug3cqiRomInfo, mslug3cqiRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	ngOc400osRhInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legend Tower Defense, Hack) - 2024-12-29
-// Modified by ?
+// Metal Slug 3 (Legend Tower Defense v5.0, Hack) - 2025-05-08
+// Modified by AKS
 
 static struct BurnRomInfo mslug3cqtfbRomDesc[] = {
-	{ "256-ph1cqt.p1",	0x100000, 0x9a40066b, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
-	{ "256-ph2cqt.sp2",	0x800000, 0xfcf952e5, 1 | BRF_ESS | BRF_PRG },	//  1 
+	{ "256-ph1cqt.p1",	0x100000, 0x8be75a1e, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
+	{ "256-ph2cqt.sp2",	0x800000, 0xf14fb1ba, 1 | BRF_ESS | BRF_PRG },	//  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },			//  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },			//  3
@@ -22738,11 +22747,11 @@ STD_ROM_FN(mslug3cqtfb)
 
 struct BurnDriver BurnDrvMslug3cqtfb = {
 	"mslug3cqtfb", "mslug3", "neogeo", NULL, "2024",
-	"Metal Slug 3 (Legend Tower Defense, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"Metal Slug 3 (Legend Tower Defense v5.0, Hack)\0", NULL, "hack (AKS)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug3cqtfbRomInfo, mslug3cqtfbRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	ngOc400osRhInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
 
@@ -22858,12 +22867,12 @@ struct BurnDriver BurnDrvMslug4lwq = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2025-02-13
-// Modified by ?
+// Metal Slug 4 (Legendary Unlimited Fire v6.0, Hack) - 2025-04-03
+// Modified by AKS & SAKURA
 
 static struct BurnRomInfo mslug4zjhlRomDesc[] = {
-	{ "263-p1zjh.p1",	0x100000, 0x7ff2f18e, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2zjh.sp2",	0x800000, 0x22abf687, 1 | BRF_ESS | BRF_PRG },  //  1
+	{ "263-p1zjh.p1",	0x100000, 0x68e0e022, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2zjh.sp2",	0x800000, 0xeba906ff, 1 | BRF_ESS | BRF_PRG },  //  1
 	
 	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
 
@@ -22871,8 +22880,8 @@ static struct BurnRomInfo mslug4zjhlRomDesc[] = {
 	{ "263-c2d.c2",		0x800000, 0x5ab0d12b, 3 | BRF_GRA },            //  4
 	{ "263-c3d.c3",		0x800000, 0x61af560c, 3 | BRF_GRA },            //  5
 	{ "263-c4d.c4",		0x800000, 0xf2c544fd, 3 | BRF_GRA },            //  6
-	{ "263-c5zjh.c5",	0x800000, 0x3b0347a0, 3 | BRF_GRA },            //  7
-	{ "263-c6zjh.c6",	0x800000, 0xe95f5ef5, 3 | BRF_GRA },            //  8
+	{ "263-c5zjh.c5",	0x800000, 0x703095cf, 3 | BRF_GRA },            //  7
+	{ "263-c6zjh.c6",	0x800000, 0x753a5f74, 3 | BRF_GRA },            //  8
 
 	{ "263-m1zjh.m1",	0x020000, 0x98e75e61, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 
@@ -22885,11 +22894,11 @@ STD_ROM_FN(mslug4zjhl)
 
 struct BurnDriver BurnDrvMslug4zjhl = {
 	"mslug4zjhl", "mslug4", "neogeo", NULL, "2025",
-	"Metal Slug 4 (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"Metal Slug 4 (Legendary Unlimited Fire v6.0, Hack)\0", NULL, "hack (AKS & SAKURA)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug4zjhlRomInfo, mslug4zjhlRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	ngOc400osRhInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 
@@ -23348,11 +23357,11 @@ struct BurnDriver BurnDrvMslug5an = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2025-04-03, P1 bug fix
+// Metal Slug 5 (The Ultimate Legend v6.0, Hack) - 2025-04-03
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0x95787416, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0x8eb713e3, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 
@@ -23376,11 +23385,11 @@ STD_ROM_FN(mslug5cq)
 
 struct BurnDriver BurnDrvMslug5cq = {
 	"mslug5cq", "mslug5", "neogeo", NULL, "2025",
-	"Metal Slug 5 (The Ultimate Legend, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"Metal Slug 5 (The Ultimate Legend v6.0, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug5cqRomInfo, mslug5cqRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	ngOc400osRhInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -22317,9 +22317,9 @@ struct BurnDriver BurnDrvmslug4lwq = {
 // Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-10-16
 // Modified by ?
 
-static struct BurnRomInfo mslug4cqiRomDesc[] = {
-	{ "263-p1cqi.p1",	0x100000, 0x41ca7c0b, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2cqi.sp2",	0x800000, 0x6fb4b241, 1 | BRF_ESS | BRF_PRG },  //  1
+static struct BurnRomInfo mslug4zjRomDesc[] = {
+	{ "263-p1zj.p1",	0x100000, 0x41ca7c0b, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2zj.sp2",	0x800000, 0x6fb4b241, 1 | BRF_ESS | BRF_PRG },  //  1
 	
 	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
 
@@ -22327,8 +22327,8 @@ static struct BurnRomInfo mslug4cqiRomDesc[] = {
 	{ "263-c2d.c2",		0x800000, 0x5ab0d12b, 3 | BRF_GRA },            //  4
 	{ "263-c3d.c3",		0x800000, 0x61af560c, 3 | BRF_GRA },            //  5
 	{ "263-c4d.c4",		0x800000, 0xf2c544fd, 3 | BRF_GRA },            //  6
-	{ "263-c5cqi.c5",	0x800000, 0xd41f13a2, 3 | BRF_GRA },            //  7
-	{ "263-c6cqi.c6",	0x800000, 0x20dae873, 3 | BRF_GRA },            //  8
+	{ "263-c5zj.c5",	0x800000, 0xd41f13a2, 3 | BRF_GRA },            //  7
+	{ "263-c6zj.c6",	0x800000, 0x20dae873, 3 | BRF_GRA },            //  8
 
 	{ "263-m1d.m1",		0x020000, 0xef5db532, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 
@@ -22336,15 +22336,15 @@ static struct BurnRomInfo mslug4cqiRomDesc[] = {
 	{ "263-v2d.v2",		0x800000, 0x20125227, 5 | BRF_SND },            // 11
 };
 
-STDROMPICKEXT(mslug4cqi, mslug4cqi, neogeo)
-STD_ROM_FN(mslug4cqi)
+STDROMPICKEXT(mslug4zj, mslug4zj, neogeo)
+STD_ROM_FN(mslug4zj)
 
-struct BurnDriver BurnDrvMslug4cqi = {
-	"mslug4cqi", "mslug4", "neogeo", NULL, "2024",
+struct BurnDriver BurnDrvMslug4zj = {
+	"mslug4zj", "mslug4", "neogeo", NULL, "2024",
 	"Metal Slug 4 (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
-	NULL, mslug4cqiRomInfo, mslug4cqiRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NULL, mslug4zjRomInfo, mslug4zjRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21940,12 +21940,12 @@ struct BurnDriver BurnDrvmslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-10-15
+// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-10-30
 // Modified by ?
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
-	{ "250-p1cqi.p1",	0x100000, 0xb6ca4046, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x400000, 0x05cd39da, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1cqi.p1",	0x100000, 0x03bb5d5c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2cqi.ep1",	0x400000, 0xfbaa1293, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -21953,8 +21953,8 @@ static struct BurnRomInfo mslugxcqiRomDesc[] = {
 	{ "250-c2.c2",		0x800000, 0x31679821, 3 | BRF_GRA },           //  4
 	{ "250-c3cqi.c3",	0x800000, 0x917f95c5, 3 | BRF_GRA },           //  5
 	{ "250-c4cqi.c4",	0x800000, 0x93290f81, 3 | BRF_GRA },           //  6
-	{ "250-c5cqi.c5",	0x800000, 0xea889f46, 3 | BRF_GRA },           //  7
-	{ "250-c6cqi.c6",	0x800000, 0x480ed637, 3 | BRF_GRA },           //  8
+	{ "250-c5cqi.c5",	0x800000, 0x9b14fbf2, 3 | BRF_GRA },           //  7
+	{ "250-c6cqi.c6",	0x800000, 0xe0e796d3, 3 | BRF_GRA },           //  8
 
 	{ "250-m1.m1",		0x020000, 0xfd42a842, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
 
@@ -22202,12 +22202,12 @@ struct BurnDriver BurnDrvmslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-10-15
+// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-10-25
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0x41becaef, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x400000, 0xe9efe7f2, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0xc36408a4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x400000, 0xdee96dc8, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
@@ -22314,12 +22314,12 @@ struct BurnDriver BurnDrvmslug4lwq = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-10-16
+// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-10-28
 // Modified by ?
 
 static struct BurnRomInfo mslug4zjRomDesc[] = {
-	{ "263-p1zj.p1",	0x100000, 0x41ca7c0b, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2zj.sp2",	0x800000, 0x6fb4b241, 1 | BRF_ESS | BRF_PRG },  //  1
+	{ "263-p1zj.p1",	0x100000, 0xdf351171, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2zj.sp2",	0x800000, 0x0fa18862, 1 | BRF_ESS | BRF_PRG },  //  1
 	
 	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
 
@@ -22330,10 +22330,10 @@ static struct BurnRomInfo mslug4zjRomDesc[] = {
 	{ "263-c5zj.c5",	0x800000, 0xd41f13a2, 3 | BRF_GRA },            //  7
 	{ "263-c6zj.c6",	0x800000, 0x20dae873, 3 | BRF_GRA },            //  8
 
-	{ "263-m1d.m1",		0x020000, 0xef5db532, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
+	{ "263-m1zj.m1",	0x020000, 0x2c722ea4, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 
-	{ "263-v1d.v1",		0x800000, 0xfd6b982e, 5 | BRF_SND },            // 10 Sound data
-	{ "263-v2d.v2",		0x800000, 0x20125227, 5 | BRF_SND },            // 11
+	{ "263-v1zj.v1",	0x800000, 0xe06d7658, 5 | BRF_SND },            // 10 Sound data
+	{ "263-v2zj.v2",	0x800000, 0xf74df238, 5 | BRF_SND },            // 11
 };
 
 STDROMPICKEXT(mslug4zj, mslug4zj, neogeo)
@@ -22804,11 +22804,11 @@ struct BurnDriver BurnDrvmslug5esr = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-10-11
+// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-11-02
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0x57de7890, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0xc14138d5, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -20791,13 +20791,13 @@ struct BurnDriver BurnDrvkf2k3ps2sp = {
 
 	Acknowledgements:
 	These people helped make the hack possible:
-	SieKensou, PsychoRFG, Ge Os, Jay Bee, leonardofmatheus, Alice???, Bunny-Head
+	SieKensou, PsychoRFG, Ge Os, Jay Bee, leonardofmatheus, Alice愛麗絲, Bunny-Head
 
 	Hack created by Matt Greer.
  *************************************************************************************/
 
 static struct BurnRomInfo kof94teRomDesc[] = {
-	{ "055-p1te.p1",	0x200000, 0x9fbece14, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "055-p1te.p1",	0x200000, 0x457d9cf7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "055-s1te.s1",	0x020000, 0xdcd024d2, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -20831,7 +20831,7 @@ struct BurnDriver BurnDrvKof94te = {
 };
 
 static struct BurnRomInfo kof94teaRomDesc[] = {
-	{ "055-p1tea.p1",	0x200000, 0x6619cc92, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "055-p1tea.p1",	0x200000, 0xbcda9e71, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "055-s1te.s1",	0x020000, 0xdcd024d2, 2 | BRF_GRA },           //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -22202,12 +22202,12 @@ struct BurnDriver BurnDrvmslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-10-25
+// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-11-15
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0xc36408a4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x400000, 0xdee96dc8, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0x6c3c8899, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x400000, 0xdf7d1bcc, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
@@ -22239,12 +22239,12 @@ struct BurnDriver BurnDrvMslug3cqi = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Tower Defense, Hack) - 2024-11-21
+// Metal Slug 3 (Legend Tower Defense, Hack) - 2024-11-22
 // Modified by ?
 
-static struct BurnRomInfo mslug3tdRomDesc[] = {
-	{ "256-ph1td.p1",	0x100000, 0x2fcba62c, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
-	{ "256-ph2td.sp2",	0x800000, 0xbfdebae1, 1 | BRF_ESS | BRF_PRG },	//  1 
+static struct BurnRomInfo mslug3cqtfbRomDesc[] = {
+	{ "256-ph1cqt.p1",	0x100000, 0x5edf4f65, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
+	{ "256-ph2cqt.sp2",	0x800000, 0x7293cded, 1 | BRF_ESS | BRF_PRG },	//  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },			//  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },			//  3
@@ -22252,8 +22252,8 @@ static struct BurnRomInfo mslug3tdRomDesc[] = {
 	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },			//  5
 	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },			//  6
 	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },			//  7
-	{ "256-c7td.c7",	0x800000, 0x9fdf02a4, 3 | BRF_GRA },			//  8
-	{ "256-c8td.c8",	0x800000, 0x6449f0c1, 3 | BRF_GRA },			//  9
+	{ "256-c7cqt.c7",	0x800000, 0x18fcdc60, 3 | BRF_GRA },			//  8
+	{ "256-c8cqt.c8",	0x800000, 0x19d95e57, 3 | BRF_GRA },			//  9
 
 	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG },	// 10 Z80 code
 
@@ -22263,16 +22263,53 @@ static struct BurnRomInfo mslug3tdRomDesc[] = {
 	{ "256-v4.v4",		0x400000, 0x9b4b22d4, 5 | BRF_SND },			// 14
 };
 
-STDROMPICKEXT(mslug3td, mslug3td, neogeo)
-STD_ROM_FN(mslug3td)
+STDROMPICKEXT(mslug3cqtfb, mslug3cqtfb, neogeo)
+STD_ROM_FN(mslug3cqtfb)
 
-struct BurnDriver BurnDrvMslug3td = {
-	"mslug3td", "mslug3", "neogeo", NULL, "2024",
-	"Metal Slug 3 (Tower Defense, Hack)\0", NULL, "hack", "Neo Geo MVS",
+struct BurnDriver BurnDrvMslug3cqtfb = {
+	"mslug3cqtfb", "mslug3", "neogeo", NULL, "2024",
+	"Metal Slug 3 (Legend Tower Defense, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
-	NULL, mslug3tdRomInfo, mslug3tdRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NULL, mslug3cqtfbRomInfo, mslug3cqtfbRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+// Metal Slug 3 (Double Enemy, Hack) - 2024-11-20
+// Modified by ?
+
+static struct BurnRomInfo mslug3esRomDesc[] = {
+	{ "256-ph1es.p1",	0x100000, 0x2922bacd, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
+	{ "256-ph2es.sp2",	0x400000, 0xd5613fc9, 1 | BRF_ESS | BRF_PRG },	//  1 
+
+	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },			//  2 Sprite data
+	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },			//  3
+	{ "256-c3d.c3",		0x800000, 0xbfaade82, 3 | BRF_GRA },			//  4
+	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },			//  5
+	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },			//  6
+	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },			//  7
+	{ "256-c7d.c7",		0x800000, 0x9395b809, 3 | BRF_GRA },			//  8
+	{ "256-c8d.c8",		0x800000, 0xa369f9d4, 3 | BRF_GRA },			//  9
+
+	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG },	// 10 Z80 code
+
+	{ "256-v1.v1",		0x400000, 0xf2690241, 5 | BRF_SND },			// 11 Sound data
+	{ "256-v2.v2",		0x400000, 0x7e2a10bd, 5 | BRF_SND },			// 12
+	{ "256-v3.v3",		0x400000, 0x0eaec17c, 5 | BRF_SND },			// 13
+	{ "256-v4.v4",		0x400000, 0x9b4b22d4, 5 | BRF_SND },			// 14
+};
+
+STDROMPICKEXT(mslug3es, mslug3es, neogeo)
+STD_ROM_FN(mslug3es)
+
+struct BurnDriver BurnDrvMslug3es = {
+	"mslug3es", "mslug3", "neogeo", NULL, "2024",
+	"Metal Slug 3 (Double Enemy, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
+	NULL, mslug3esRomInfo, mslug3esRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
 
@@ -22354,9 +22391,9 @@ struct BurnDriver BurnDrvmslug4lwq = {
 // Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-11-10
 // Modified by ?
 
-static struct BurnRomInfo mslug4zjRomDesc[] = {
-	{ "263-p1zj.p1",	0x100000, 0xdf351171, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2zj.sp2",	0x800000, 0x0fa18862, 1 | BRF_ESS | BRF_PRG },  //  1
+static struct BurnRomInfo mslug4zjhlRomDesc[] = {
+	{ "263-p1zjh.p1",	0x100000, 0x1875cf9c, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2zjh.sp2",	0x800000, 0x0b2724f0, 1 | BRF_ESS | BRF_PRG },  //  1
 	
 	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
 
@@ -22364,24 +22401,24 @@ static struct BurnRomInfo mslug4zjRomDesc[] = {
 	{ "263-c2d.c2",		0x800000, 0x5ab0d12b, 3 | BRF_GRA },            //  4
 	{ "263-c3d.c3",		0x800000, 0x61af560c, 3 | BRF_GRA },            //  5
 	{ "263-c4d.c4",		0x800000, 0xf2c544fd, 3 | BRF_GRA },            //  6
-	{ "263-c5zj.c5",	0x800000, 0x3b0347a0, 3 | BRF_GRA },            //  7
-	{ "263-c6zj.c6",	0x800000, 0xe95f5ef5, 3 | BRF_GRA },            //  8
+	{ "263-c5zjh.c5",	0x800000, 0x3b0347a0, 3 | BRF_GRA },            //  7
+	{ "263-c6zjh.c6",	0x800000, 0xe95f5ef5, 3 | BRF_GRA },            //  8
 
-	{ "263-m1zj.m1",	0x020000, 0x2c722ea4, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
+	{ "263-m1zjh.m1",	0x020000, 0x2c722ea4, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 
-	{ "263-v1zj.v1",	0x800000, 0xe06d7658, 5 | BRF_SND },            // 10 Sound data
-	{ "263-v2zj.v2",	0x800000, 0xf74df238, 5 | BRF_SND },            // 11
+	{ "263-v1zjh.v1",	0x800000, 0xe06d7658, 5 | BRF_SND },            // 10 Sound data
+	{ "263-v2zjh.v2",	0x800000, 0xf74df238, 5 | BRF_SND },            // 11
 };
 
-STDROMPICKEXT(mslug4zj, mslug4zj, neogeo)
-STD_ROM_FN(mslug4zj)
+STDROMPICKEXT(mslug4zjhl, mslug4zjhl, neogeo)
+STD_ROM_FN(mslug4zjhl)
 
-struct BurnDriver BurnDrvMslug4zj = {
-	"mslug4zj", "mslug4", "neogeo", NULL, "2024",
+struct BurnDriver BurnDrvMslug4zjhl = {
+	"mslug4zjhl", "mslug4", "neogeo", NULL, "2024",
 	"Metal Slug 4 (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
-	NULL, mslug4zjRomInfo, mslug4zjRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NULL, mslug4zjhlRomInfo, mslug4zjhlRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
@@ -22498,37 +22535,37 @@ struct BurnDriver BurnDrvmslug5dbj = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (Extremely Simplified, Hack)
-// Modified by 明天再努力吧
+// Metal Slug 5 (Double Enemy, Hack) - 2023-12-29
+// Modified by ?
 
 static struct BurnRomInfo mslug5esRomDesc[] = {
-	{ "268-p1es.p1",    0x600000, 0x760cd052, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1es.p1",	0x600000, 0x8f8327a1, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
-	{ "268-s1d.s1",     0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
+	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 
-	{ "268-c1do.c1",    0x800000, 0x969c0d62, 3 | BRF_GRA },            //  2 Sprite data
-	{ "268-c2do.c2",    0x800000, 0xc69ae867, 3 | BRF_GRA },            //  3
-	{ "268-c3do.c3",    0x800000, 0xd7beaeaf, 3 | BRF_GRA },            //  4
-	{ "268-c4do.c4",    0x800000, 0xe1b1131b, 3 | BRF_GRA },            //  5
-	{ "268-c5do.c5",    0x800000, 0x2fa1a5ad, 3 | BRF_GRA },            //  6
-	{ "268-c6do.c6",    0x800000, 0x6de89589, 3 | BRF_GRA },            //  7
-	{ "268-c7do.c7",    0x800000, 0x97bd0c0a, 3 | BRF_GRA },            //  8
-	{ "268-c8do.c8",    0x800000, 0xc0d5bc20, 3 | BRF_GRA },            //  9
+	{ "268-c1do.c1",	0x800000, 0x969c0d62, 3 | BRF_GRA },            //  2 Sprite data
+	{ "268-c2do.c2",	0x800000, 0xc69ae867, 3 | BRF_GRA },            //  3
+	{ "268-c3do.c3",	0x800000, 0xd7beaeaf, 3 | BRF_GRA },            //  4
+	{ "268-c4do.c4",	0x800000, 0xe1b1131b, 3 | BRF_GRA },            //  5
+	{ "268-c5do.c5",	0x800000, 0x2fa1a5ad, 3 | BRF_GRA },            //  6
+	{ "268-c6do.c6",	0x800000, 0x6de89589, 3 | BRF_GRA },            //  7
+	{ "268-c7do.c7",	0x800000, 0x97bd0c0a, 3 | BRF_GRA },            //  8
+	{ "268-c8do.c8",	0x800000, 0xc0d5bc20, 3 | BRF_GRA },            //  9
 
-	{ "268-m1do.m1",    0x020000, 0x6fa01c9a, 4 | BRF_ESS | BRF_PRG },  // 10 Z80 code
+	{ "268-m1do.m1",	0x020000, 0x6fa01c9a, 4 | BRF_ESS | BRF_PRG },  // 10 Z80 code
 
-	{ "268-v1do.v1",    0x400000, 0xc3540e0d, 5 | BRF_SND },            // 11 Sound data
-	{ "268-v2do.v2",    0x400000, 0x077bd2f4, 5 | BRF_SND },            // 12
-	{ "268-v3do.v3",    0x400000, 0x39b14567, 5 | BRF_SND },            // 13
-	{ "268-v4do.v4",    0x400000, 0x969ff3b2, 5 | BRF_SND },            // 14
+	{ "268-v1do.v1",	0x400000, 0xc3540e0d, 5 | BRF_SND },            // 11 Sound data
+	{ "268-v2do.v2",	0x400000, 0x077bd2f4, 5 | BRF_SND },            // 12
+	{ "268-v3do.v3",	0x400000, 0x39b14567, 5 | BRF_SND },            // 13
+	{ "268-v4do.v4",	0x400000, 0x969ff3b2, 5 | BRF_SND },            // 14
 };
 
 STDROMPICKEXT(mslug5es, mslug5es, neogeo)
 STD_ROM_FN(mslug5es)
 
 struct BurnDriver BurnDrvmslug5es = {
-	"mslug5es", "mslug5", "neogeo", NULL, "2022",
-	"Metal Slug 5 (Extremely Simplified, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"mslug5es", "mslug5", "neogeo", NULL, "2023",
+	"Metal Slug 5 (Double Enemy, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug5esRomInfo, mslug5esRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
@@ -22803,11 +22840,11 @@ struct BurnDriver BurnDrvmslug5ct = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (Double Enemy, Hack) - 2023-12-29
-// Modified by ?
+// Metal Slug 5 (Extremely Simplified, Hack) - 2024-10-10
+// Modified by 明天再努力吧
 
-static struct BurnRomInfo mslug5esrRomDesc[] = {
-	{ "268-p1esr.p1",	0x600000, 0x8f8327a1, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+static struct BurnRomInfo mslug5anRomDesc[] = {
+	{ "268-p1an.p1",	0x600000, 0x022c7fe1, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 
@@ -22828,24 +22865,24 @@ static struct BurnRomInfo mslug5esrRomDesc[] = {
 	{ "268-v4do.v4",	0x400000, 0x969ff3b2, 5 | BRF_SND },            // 14
 };
 
-STDROMPICKEXT(mslug5esr, mslug5esr, neogeo)
-STD_ROM_FN(mslug5esr)
+STDROMPICKEXT(mslug5an, mslug5an, neogeo)
+STD_ROM_FN(mslug5an)
 
-struct BurnDriver BurnDrvmslug5esr = {
-	"mslug5esr", "mslug5", "neogeo", NULL, "2023",
-	"Metal Slug 5 (Double Enemy, Hack)\0", NULL, "hack", "Neo Geo MVS",
+struct BurnDriver BurnDrvmslug5an = {
+	"mslug5an", "mslug5", "neogeo", NULL, "2022",
+	"Metal Slug 5 (Extremely Simplified, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
-	NULL, mslug5esrRomInfo, mslug5esrRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NULL, mslug5anRomInfo, mslug5anRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-11-02
+// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-11-07
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0xc14138d5, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0x7ba1f376, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21940,12 +21940,12 @@ struct BurnDriver BurnDrvmslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-10-30
+// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-12-02
 // Modified by ?
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
 	{ "250-p1cqi.p1",	0x100000, 0x03bb5d5c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x400000, 0xfbaa1293, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p2cqi.ep1",	0x400000, 0x03fc0122, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -22202,12 +22202,12 @@ struct BurnDriver BurnDrvmslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-11-15
+// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-12-03
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0x6c3c8899, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x400000, 0xdf7d1bcc, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0x458ec1b4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x400000, 0x7c5c94d6, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
@@ -22239,12 +22239,12 @@ struct BurnDriver BurnDrvMslug3cqi = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legend Tower Defense, Hack) - 2024-11-22
+// Metal Slug 3 (Legend Tower Defense, Hack) - 2024-12-03
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqtfbRomDesc[] = {
-	{ "256-ph1cqt.p1",	0x100000, 0x5edf4f65, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
-	{ "256-ph2cqt.sp2",	0x800000, 0x7293cded, 1 | BRF_ESS | BRF_PRG },	//  1 
+	{ "256-ph1cqt.p1",	0x100000, 0x4ad95272, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
+	{ "256-ph2cqt.sp2",	0x800000, 0x7a34c4e5, 1 | BRF_ESS | BRF_PRG },	//  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },			//  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },			//  3
@@ -22252,8 +22252,8 @@ static struct BurnRomInfo mslug3cqtfbRomDesc[] = {
 	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },			//  5
 	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },			//  6
 	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },			//  7
-	{ "256-c7cqt.c7",	0x800000, 0x18fcdc60, 3 | BRF_GRA },			//  8
-	{ "256-c8cqt.c8",	0x800000, 0x19d95e57, 3 | BRF_GRA },			//  9
+	{ "256-c7cqt.c7",	0x800000, 0x56f71abe, 3 | BRF_GRA },			//  8
+	{ "256-c8cqt.c8",	0x800000, 0xa2f280f6, 3 | BRF_GRA },			//  9
 
 	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG },	// 10 Z80 code
 
@@ -22388,12 +22388,12 @@ struct BurnDriver BurnDrvmslug4lwq = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-11-10
+// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-12-02
 // Modified by ?
 
 static struct BurnRomInfo mslug4zjhlRomDesc[] = {
-	{ "263-p1zjh.p1",	0x100000, 0x1875cf9c, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2zjh.sp2",	0x800000, 0x0b2724f0, 1 | BRF_ESS | BRF_PRG },  //  1
+	{ "263-p1zjh.p1",	0x100000, 0x2403ce15, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2zjh.sp2",	0x800000, 0xe0ed3fe0, 1 | BRF_ESS | BRF_PRG },  //  1
 	
 	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
 
@@ -22878,11 +22878,11 @@ struct BurnDriver BurnDrvmslug5an = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-11-07
+// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-12-03
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0x7ba1f376, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0xa90e4f49, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -22314,7 +22314,7 @@ struct BurnDriver BurnDrvmslug4lwq = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 4 (CQI, Hack) - 2024-10-16
+// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-10-16
 // Modified by ?
 
 static struct BurnRomInfo mslug4cqiRomDesc[] = {
@@ -22341,11 +22341,11 @@ STD_ROM_FN(mslug4cqi)
 
 struct BurnDriver BurnDrvMslug4cqi = {
 	"mslug4cqi", "mslug4", "neogeo", NULL, "2024",
-	"Metal Slug 4 (CQI, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"Metal Slug 4 (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug4cqiRomInfo, mslug4cqiRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -16025,33 +16025,33 @@ struct BurnDriver BurnDrvKof2k2plus = {
 	0x1000,	304, 224, 4, 3
 };
 
-// The King of Fighters '96 (NGM-214, alternate board)
+// The King of Fighters '96 (bug fix revision)
 /* MVS VERSION */
 
 static struct BurnRomInfo kof96aRomDesc[] = {
 	/* This set uses NEO-MVS PROGSS3 board; same rom data as in kof96h is used */
-	{ "214-epr.ep1",  0x080000, 0xa6101486, 1 | BRF_ESS | BRF_PRG }, //  0 68K code 		/ 27C240  / 27C4096
-	{ "214-epr.ep2",  0x080000, 0x6abc7ae5, 1 | BRF_ESS | BRF_PRG }, //  1 					/ 27C4096 / 27C4096
-	{ "214-epr.ep3",  0x080000, 0xa588dff4, 1 | BRF_ESS | BRF_PRG }, //  2 					/ 27C240  / 27C4096
-	{ "214-epr.ep4",  0x080000, 0x6d6f17eb, 1 | BRF_ESS | BRF_PRG }, //  3 					/ 27C240  / 27C4096
-	{ "214-p5.p5",    0x200000, 0xbf81a853, 1 | BRF_ESS | BRF_PRG }, //  4 					/ TC5316200CP */
+	{ "blue.ep1",		0x080000, 0xa6101486, 1 | BRF_ESS | BRF_PRG }, //  0 68K code 		/ 27C240  / 27C4096
+	{ "red.ep2",		0x080000, 0x6abc7ae5, 1 | BRF_ESS | BRF_PRG }, //  1 					/ 27C4096 / 27C4096
+	{ "orange.ep3",		0x080000, 0xa588dff4, 1 | BRF_ESS | BRF_PRG }, //  2 					/ 27C240  / 27C4096
+	{ "yellow.ep4",		0x080000, 0x6d6f17eb, 1 | BRF_ESS | BRF_PRG }, //  3 					/ 27C240  / 27C4096
+	{ "214-p5.p5",		0x100000, 0x9f3c6bc9, 1 | BRF_ESS | BRF_PRG }, //  4 					/ TC5316200CP
 
-	{ "214-s1.s1",    0x020000, 0x1254cbdb, 2 | BRF_GRA },           //  5 Text layer tiles / TC531000
+	{ "214-s1.s1",		0x020000, 0x1254cbdb, 2 | BRF_GRA },           //  5 Text layer tiles / TC531000
 
-	{ "214-c1.c1",    0x400000, 0x7ecf4aa2, 3 | BRF_GRA },           //  6 Sprite data		/ TC5332205
-	{ "214-c2.c2",    0x400000, 0x05b54f37, 3 | BRF_GRA },           //  7 					/ TC5332205
-	{ "214-c3.c3",    0x400000, 0x64989a65, 3 | BRF_GRA },           //  8 					/ TC5332205
-	{ "214-c4.c4",    0x400000, 0xafbea515, 3 | BRF_GRA },           //  9 					/ TC5332205
-	{ "214-c5.c5",    0x400000, 0x2a3bbd26, 3 | BRF_GRA },           // 10 					/ TC5332205
-	{ "214-c6.c6",    0x400000, 0x44d30dc7, 3 | BRF_GRA },           // 11 					/ TC5332205
-	{ "214-c7.c7",    0x400000, 0x3687331b, 3 | BRF_GRA },           // 12 					/ TC5332205
-	{ "214-c8.c8",    0x400000, 0xfa1461ad, 3 | BRF_GRA },           // 13 					/ TC5332205
+	{ "214-c1.c1",		0x400000, 0x7ecf4aa2, 3 | BRF_GRA },           //  6 Sprite data		/ TC5332205
+	{ "214-c2.c2",		0x400000, 0x05b54f37, 3 | BRF_GRA },           //  7 					/ TC5332205
+	{ "214-c3.c3",		0x400000, 0x64989a65, 3 | BRF_GRA },           //  8 					/ TC5332205
+	{ "214-c4.c4",		0x400000, 0xafbea515, 3 | BRF_GRA },           //  9 					/ TC5332205
+	{ "214-c5.c5",		0x400000, 0x2a3bbd26, 3 | BRF_GRA },           // 10 					/ TC5332205
+	{ "214-c6.c6",		0x400000, 0x44d30dc7, 3 | BRF_GRA },           // 11 					/ TC5332205
+	{ "214-c7.c7",		0x400000, 0x3687331b, 3 | BRF_GRA },           // 12 					/ TC5332205
+	{ "214-c8.c8",		0x400000, 0xfa1461ad, 3 | BRF_GRA },           // 13 					/ TC5332205
 
-	{ "214-m1.m1",    0x020000, 0xdabc427c, 4 | BRF_ESS | BRF_PRG }, // 14 Z80 code			/ TC531001
+	{ "214-m1.m1",		0x020000, 0xdabc427c, 4 | BRF_ESS | BRF_PRG }, // 14 Z80 code			/ TC531001
 
-	{ "214-v1.v1",    0x400000, 0x63f7b045, 5 | BRF_SND },           // 15 Sound data		/ TC5332204
-	{ "214-v2.v2",    0x400000, 0x25929059, 5 | BRF_SND },           // 16 					/ TC5332204
-	{ "214-v3.v3",    0x200000, 0x92a2257d, 5 | BRF_SND },           // 17 					/ TC5316200
+	{ "214-v1.v1",		0x400000, 0x63f7b045, 5 | BRF_SND },           // 15 Sound data		/ TC5332204
+	{ "214-v2.v2",		0x400000, 0x25929059, 5 | BRF_SND },           // 16 					/ TC5332204
+	{ "214-v3.v3",		0x200000, 0x92a2257d, 5 | BRF_SND },           // 17 					/ TC5316200
 };
 
 STDROMPICKEXT(kof96a, kof96a, neogeo)
@@ -16059,7 +16059,7 @@ STD_ROM_FN(kof96a)
 
 struct BurnDriver BurnDrvKof96a = {
 	"kof96a", "kof96", "neogeo", NULL, "1996",
-	"The King of Fighters '96 (NGM-214, alternate board)\0", NULL, "SNK", "Neo Geo MVS",
+	"The King of Fighters '96 (bug fix revision)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO,  GBF_VSFIGHT, FBF_KOF,
 	NULL, kof96aRomInfo, kof96aRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
@@ -20788,6 +20788,44 @@ struct BurnDriver BurnDrvKof2000bc = {
 	0x1000,	304, 224, 4, 3
 };
 
+// The King of Fighters 2000 (Special, Hack)
+// Modified by GSC2007 & EGCG
+// GOTVG 20230306
+
+static struct BurnRomInfo kof2kspRomDesc[] = {
+	{ "257-p1sp.p1",	0x100000, 0xa9742061, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "257-p2sp.sp2",	0x400000, 0x48a1a381, 1 | BRF_ESS | BRF_PRG }, //  1
+	
+	{ "257-c1d.c1",		0x800000, 0xabcdd424, 3 | BRF_GRA },           //  2 Sprite data
+	{ "257-c2d.c2",		0x800000, 0xcda33778, 3 | BRF_GRA },           //  3
+	{ "257-c3d.c3",		0x800000, 0x087fb15b, 3 | BRF_GRA },           //  4
+	{ "257-c4d.c4",		0x800000, 0xfe9dfde4, 3 | BRF_GRA },           //  5
+	{ "257-c5d.c5",		0x800000, 0x03ee4bf4, 3 | BRF_GRA },           //  6
+	{ "257-c6d.c6",		0x800000, 0x8599cc5b, 3 | BRF_GRA },           //  7
+	{ "257-c7sp.c7",	0x800000, 0x110f72a3, 3 | BRF_GRA },           //  8
+	{ "257-c8sp.c8",	0x800000, 0x4347f6af, 3 | BRF_GRA },           //  9
+
+	{ "257-m1d.m1",		0x040000, 0xd404db70, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
+
+	{ "257-v1.v1",		0x400000, 0x17cde847, 5 | BRF_SND },           // 11 Sound data
+	{ "257-v2.v2",		0x400000, 0x1afb20ff, 5 | BRF_SND },           // 12
+	{ "257-v3.v3",		0x400000, 0x4605036a, 5 | BRF_SND },           // 13
+	{ "257-v4.v4",		0x400000, 0x764bbd6b, 5 | BRF_SND },           // 14
+};
+
+STDROMPICKEXT(kof2ksp, kof2ksp, neogeo)
+STD_ROM_FN(kof2ksp)
+
+struct BurnDriver BurnDrvKof2ksp = {
+	"kof2ksp", "kof2000", "neogeo", NULL, "2023",
+	"The King of Fighters 2000 (Special, Hack)\0", NULL, "hack (GSC2007 & EGCG)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_ALTERNATE_TEXT, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof2kspRomInfo, kof2kspRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
 // The King of Fighters 2000 SP XXX (Hack)
 
 static struct BurnRomInfo kof2kxxxRomDesc[] = {
@@ -20827,6 +20865,134 @@ struct BurnDriver BurnDrvKof2kxxx = {
 	kof2000nInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
+
+
+// The King of Fighters 2001 (Ultimate, Hack)
+// Modified by 西岐赏金猎人, 臂力哥
+// GOTVG 20250126
+
+static struct BurnRomInfo kf2k1ultRomDesc[] = {
+	{ "262-p1ult.p1",		0x100000, 0x7fb7ea52, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "262-p2ult.sp2",		0x500000, 0x6be21453, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "262-s1ult.s1",		0x020000, 0x6bceef77, 2 | BRF_GRA },           //  2 Text layer tiles
+	
+	{ "262-c1ult.c1",		0x800000, 0xc2486ac2, 3 | BRF_GRA },           //  3 Sprite data
+	{ "262-c2ult.c2",		0x800000, 0x6614bacb, 3 | BRF_GRA },           //  4
+	{ "262-c3ult.c3",		0x800000, 0xa164f2c2, 3 | BRF_GRA },           //  5
+	{ "262-c4ult.c4",		0x800000, 0x649dc7fa, 3 | BRF_GRA },           //  6
+	{ "262-c5ult.c5",		0x800000, 0xb47e4f8d, 3 | BRF_GRA },           //  7
+	{ "262-c6ult.c6",		0x800000, 0xac5f2083, 3 | BRF_GRA },           //  8
+	{ "262-c7ult.c7",		0x800000, 0x8e0d191a, 3 | BRF_GRA },           //  9
+	{ "262-c8ult.c8",		0x800000, 0x6fea378f, 3 | BRF_GRA },           // 10
+	{ "262-c9ult.c9",		0x800000, 0xcf4b24ef, 3 | BRF_GRA },           // 11
+	{ "262-c10ult.c10",		0x800000, 0x4f20d0ff, 3 | BRF_GRA },           // 12
+	{ "265-c7d.c7",			0x800000, 0x8a5b561c, 3 | BRF_GRA },           // 13
+	{ "265-c8d.c8",			0x800000, 0xbef667a3, 3 | BRF_GRA },           // 14
+	{ "262-c13ult.c13",		0x800000, 0x19a099eb, 3 | BRF_GRA },           // 15
+	{ "262-c14ult.c14",		0x800000, 0x19a099eb, 3 | BRF_GRA },           // 16
+
+	{ "262-m1ult.m1",		0x020000, 0xd0651ea0, 4 | BRF_ESS | BRF_PRG }, // 17 Z80 code
+
+	{ "262-v1ult-08-e0.v1",	0x400000, 0xe1496ace, 5 | BRF_SND },     // 18 Sound data
+	{ "262-v2ult-08-e0.v2",	0x400000, 0x51bd6805, 5 | BRF_SND },     // 19
+	{ "262-v3ult-08-e0.v3",	0x400000, 0x6cecc242, 5 | BRF_SND },     // 20
+	{ "262-v4ult-08-e0.v4",	0x400000, 0x81e7a417, 5 | BRF_SND },     // 21
+	{ "262-v5ult-08-e0.v5",	0x400000, 0x42423d32, 5 | BRF_SND },     // 22
+	{ "262-v6ult-08-e0.v6",	0x400000, 0x73a03cbf, 5 | BRF_SND },     // 23
+	{ "262-v7ult-08-e0.v7",	0x400000, 0x7a2d38df, 5 | BRF_SND },     // 24
+};
+
+STDROMPICKEXT(kf2k1ult, kf2k1ult, neogeo)
+STD_ROM_FN(kf2k1ult)
+
+struct BurnDriver BurnDrvKf2k1ult = {
+	"kf2k1ult", "kof2001", "neogeo", NULL, "2025",
+	"The King of Fighters 2001 (All Boss Plus, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, L"\u897f\u5c90\u8d4f\u91d1\u730e\u4eba, \u81c2\u529b\u54e5", NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kf2k1ultRomInfo, kf2k1ultRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+
+// The King of Fighters 2002 (Climax, Hack)
+// Modified by GSC2007
+// GOTVG 20161204
+
+static struct BurnRomInfo kf2k2mixRomDesc[] = {
+	{ "265-p1mix.p1",	0x100000, 0x7ff93e96, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "265-p2mix.sp2",	0x400000, 0x01f474fa, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "265-s1ru.s1",	0x020000, 0xbd19c308, 2 | BRF_GRA },           //  2 Text layer tiles
+	
+	{ "265-c1d.c1",		0x800000, 0x7efa6ef7, 3 | BRF_GRA },           //  2 Sprite data
+	{ "265-c2d.c2",		0x800000, 0xaa82948b, 3 | BRF_GRA },           //  3
+	{ "265-c3ru.c3",	0x800000, 0xca656090, 3 | BRF_GRA },           //  4
+	{ "265-c4ru.c4",	0x800000, 0xeb898849, 3 | BRF_GRA },           //  5
+	{ "265-c5d.c5",		0x800000, 0x74bba7c6, 3 | BRF_GRA },           //  6
+	{ "265-c6d.c6",		0x800000, 0xe20d2216, 3 | BRF_GRA },           //  7
+	{ "265-c7mix.c7",	0x800000, 0x629bdf0e, 3 | BRF_GRA },           //  8
+	{ "265-c8mix.c8",	0x800000, 0xc7c8c75c, 3 | BRF_GRA },           //  9
+
+	{ "265-m1ru.m1",	0x020000, 0x9956ccd8, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
+
+	{ "265-v1ru.v1",	0x800000, 0x6e7e3508, 5 | BRF_SND },           // 11 Sound data
+	{ "265-v2ru.v2",	0x800000, 0x2157b90f, 5 | BRF_SND },           // 12
+};
+
+STDROMPICKEXT(kf2k2mix, kf2k2mix, neogeo)
+STD_ROM_FN(kf2k2mix)
+
+struct BurnDriver BurnDrvKf2k2mix = {
+	"kf2k2mix", "kof2002", "neogeo", NULL, "2016",
+	"The King of Fighters 2002 (Climax, Hack)\0", NULL, "hack (GSC2007)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kf2k2mixRomInfo, kf2k2mixRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000,	304, 224, 4, 3
+};
+
+// The King of Fighters 2002 Plus (Optimised, Hack)
+// Modified by GSC2007
+// GOTVG 20141209
+
+static struct BurnRomInfo kof2002tRomDesc[] = {
+	{ "265-p1t.p1",		0x100000, 0x55a19ab8, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "265-p2t.sp2",	0x400000, 0x0a189c94, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "265-s1d.s1",		0x020000, 0xe0eaaba3, 2 | BRF_GRA },           //  2 Text layer tiles
+	
+	{ "265-c1d.c1",		0x800000, 0x7efa6ef7, 3 | BRF_GRA },           //  2 Sprite data
+	{ "265-c2d.c2",		0x800000, 0xaa82948b, 3 | BRF_GRA },           //  3
+	{ "265-c3d.c3",		0x800000, 0x959fad0b, 3 | BRF_GRA },           //  4
+	{ "265-c4d.c4",		0x800000, 0xefe6a468, 3 | BRF_GRA },           //  5
+	{ "265-c5d.c5",		0x800000, 0x74bba7c6, 3 | BRF_GRA },           //  6
+	{ "265-c6d.c6",		0x800000, 0xe20d2216, 3 | BRF_GRA },           //  7
+	{ "265-c7d.c7",		0x800000, 0x8a5b561c, 3 | BRF_GRA },           //  8
+	{ "265-c8d.c8",		0x800000, 0xbef667a3, 3 | BRF_GRA },           //  9
+
+	{ "265-m1d.m1",		0x020000, 0x1c661a4b, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
+
+	{ "265-v1d.v1",		0x800000, 0x0fc9a58d, 5 | BRF_SND },           // 11 Sound data
+	{ "265-v2d.v2",		0x800000, 0xb8c475a4, 5 | BRF_SND },           // 12
+};
+
+STDROMPICKEXT(kof2002t, kof2002t, neogeo)
+STD_ROM_FN(kof2002t)
+
+struct BurnDriver BurnDrvKof2002t = {
+	"kof2002t", "kof2002", "neogeo", NULL, "2014",
+	"The King of Fighters 2002 Plus (Optimised, Hack)\0", NULL, "hack (GSC2007)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof2002tRomInfo, kof2002tRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000,	304, 224, 4, 3
+};
+
 
 // The King of Fighters 2003 - PS2 Style Portraits (Hack)
 // Hack By 0 Day-S,Eddids,Hiker
@@ -20946,6 +21112,46 @@ struct BurnDriver BurnDrvKof94tea = {
 	0x1000, 304, 224, 4, 3
 };
 
+
+// The King of Fighters '96 (Plus, Hack)
+// GOTVG 20030205
+
+static struct BurnRomInfo kof96plsRomDesc[] = {
+	{ "214-p1p.p1",		0x100000, 0x76fc560c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "214-p2.sp2",		0x200000, 0x002ccb73, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "214-s1.s1",		0x020000, 0x1254cbdb, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "214-c1.c1",		0x400000, 0x7ecf4aa2, 3 | BRF_GRA },           //  3 Sprite data
+	{ "214-c2.c2",		0x400000, 0x05b54f37, 3 | BRF_GRA },           //  4
+	{ "214-c3.c3",		0x400000, 0x64989a65, 3 | BRF_GRA },           //  5
+	{ "214-c4.c4",		0x400000, 0xafbea515, 3 | BRF_GRA },           //  6
+	{ "214-c5.c5",		0x400000, 0x2a3bbd26, 3 | BRF_GRA },           //  7
+	{ "214-c6.c6",		0x400000, 0x44d30dc7, 3 | BRF_GRA },           //  8
+	{ "214-c7.c7",		0x400000, 0x3687331b, 3 | BRF_GRA },           //  9
+	{ "214-c8.c8",		0x400000, 0xfa1461ad, 3 | BRF_GRA },           // 10
+
+	{ "214-m1.m1",		0x020000, 0xdabc427c, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+
+	{ "214-v1.v1",		0x400000, 0x63f7b045, 5 | BRF_SND },           // 12 Sound data
+	{ "214-v2.v2",		0x400000, 0x25929059, 5 | BRF_SND },           // 13
+	{ "214-v3.v3",		0x200000, 0x92a2257d, 5 | BRF_SND },           // 14
+};
+
+STDROMPICKEXT(kof96pls, kof96pls, neogeo)
+STD_ROM_FN(kof96pls)
+
+struct BurnDriver BurnDrvKof96pls = {
+	"kof96pls", "kof96", "neogeo", NULL, "2003",
+	"The King of Fighters '96 (Plus, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof96plsRomInfo, kof96plsRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+
 // The King of Fighters '97 Bing Edition (Hack)
 
 static struct BurnRomInfo kof97bngRomDesc[] = {
@@ -21013,6 +21219,42 @@ struct BurnDriver BurnDrvKof97bt = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof97btRomInfo, kof97btRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+// The King of Fighters '97 (Evolution & Balance, Hack)
+// GOTVG 20231217
+
+static struct BurnRomInfo kof97ebRomDesc[] = {
+	{ "232-p1eb.p1",	0x100000, 0xc602e1c7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "232-p2eb.sp2",	0x400000, 0x9b4f127a, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "232-s1.s1",		0x020000, 0x8514ecf5, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "232-c1eb.c1",	0x800000, 0x5b382241, 3 | BRF_GRA },           //  3 Sprite data
+	{ "232-c2eb.c2",	0x800000, 0x6060de03, 3 | BRF_GRA },           //  4
+	{ "232-c3.c3",		0x800000, 0x581d6618, 3 | BRF_GRA },           //  5
+	{ "232-c4.c4",		0x800000, 0x49bb1e68, 3 | BRF_GRA },           //  6
+	{ "232-c5.c5",		0x400000, 0x34fc4e51, 3 | BRF_GRA },           //  7
+	{ "232-c6.c6",		0x400000, 0x4ff4d47b, 3 | BRF_GRA },           //  8
+
+	{ "232-m1.m1",		0x020000, 0x45348747, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+
+	{ "232-v1.v1",		0x400000, 0x22a2b5b5, 5 | BRF_SND },           // 10 Sound data
+	{ "232-v2.v2",		0x400000, 0x2304e744, 5 | BRF_SND },           // 11
+	{ "232-v3.v3",		0x400000, 0x759eb954, 5 | BRF_SND },           // 12
+};
+
+STDROMPICKEXT(kof97eb, kof97eb, neogeo)
+STD_ROM_FN(kof97eb)
+
+struct BurnDriver BurnDrvKof97eb = {
+	"kof97eb", "kof97", "neogeo", NULL, "2023",
+	"The King of Fighters '97 (Evolution & Balance, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof97ebRomInfo, kof97ebRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -21086,6 +21328,43 @@ struct BurnDriver BurnDrvKof97ratio = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof97ratioRomInfo, kof97ratioRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+// The King of Fighters '97 (Special, Hack)
+// Modified by GSC2007
+// 20150315
+
+static struct BurnRomInfo kof97spRomDesc[] = {
+	{ "232-p1sp.p1",	0x100000, 0xa511714d, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "232-p2sp.sp2",	0x400000, 0xd9e51750, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "232-s1sp.s1",	0x020000, 0xba445f53, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "232-c1sp.c1",	0x800000, 0xb7f5a3b9, 3 | BRF_GRA },           //  3 Sprite data
+	{ "232-c2sp.c2",	0x800000, 0x959d6d78, 3 | BRF_GRA },           //  4
+	{ "232-c3.c3",		0x800000, 0x581d6618, 3 | BRF_GRA },           //  5
+	{ "232-c4.c4",		0x800000, 0x49bb1e68, 3 | BRF_GRA },           //  6
+	{ "232-c5.c5",		0x400000, 0x34fc4e51, 3 | BRF_GRA },           //  7
+	{ "232-c6.c6",		0x400000, 0x4ff4d47b, 3 | BRF_GRA },           //  8
+
+	{ "232-m1.m1",		0x020000, 0x45348747, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+
+	{ "232-v1.v1",		0x400000, 0x22a2b5b5, 5 | BRF_SND },           // 10 Sound data
+	{ "232-v2.v2",		0x400000, 0x2304e744, 5 | BRF_SND },           // 11
+	{ "232-v3.v3",		0x400000, 0x759eb954, 5 | BRF_SND },           // 12
+};
+
+STDROMPICKEXT(kof97sp, kof97sp, neogeo)
+STD_ROM_FN(kof97sp)
+
+struct BurnDriver BurnDrvKof97sp = {
+	"kof97sp", "kof97", "neogeo", NULL, "2015",
+	"The King of Fighters '97 (Special, Hack)\0", NULL, "hack (GSC2007)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof97spRomInfo, kof97spRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -21560,6 +21839,47 @@ struct BurnDriver BurnDrvKof99co2 = {
 	0x1000, 304, 224, 4, 3
 };
 
+// The King of Fighters '99 - Millennium Battle (LC+SK, Hack)
+// Modified by LIY
+// GOTVG 20250309
+
+static struct BurnRomInfo kof99skRomDesc[] = {
+	{ "152-p1sk.p1",	0x100000, 0xccfb323c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "152-p2sk.sp2",	0x400000, 0xd322fb59, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "251-s1d.s1",		0x020000, 0x1b0133fe, 2 | BRF_GRA },           //  2 Text layer tiles
+	
+	{ "251-c1d.c1",		0x800000, 0xb3d88546, 3 | BRF_GRA },           //  3 Sprite data
+	{ "251-c2d.c2",		0x800000, 0x915c8634, 3 | BRF_GRA },           //  4
+	{ "251-c3d.c3",		0x800000, 0xb047c9d5, 3 | BRF_GRA },           //  5
+	{ "251-c4d.c4",		0x800000, 0x6bc8e4b1, 3 | BRF_GRA },           //  6
+	{ "251-c5d.c5",		0x800000, 0x9746268c, 3 | BRF_GRA },           //  7
+	{ "251-c6d.c6",		0x800000, 0x238b3e71, 3 | BRF_GRA },           //  8
+	{ "251-c7d.c7",		0x800000, 0x2f68fdeb, 3 | BRF_GRA },           //  9
+	{ "251-c8d.c8",		0x800000, 0x4c2fad1e, 3 | BRF_GRA },           // 10
+
+	{ "251-m1.m1",		0x020000, 0x5e74539c, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+
+	{ "251-v1.v1",		0x400000, 0xef2eecc8, 5 | BRF_SND },           // 12 Sound data
+	{ "251-v2.v2",		0x400000, 0x73e211ca, 5 | BRF_SND },           // 13
+	{ "251-v3.v3",		0x400000, 0x821901da, 5 | BRF_SND },           // 14
+	{ "251-v4.v4",		0x200000, 0xb49e6178, 5 | BRF_SND },           // 15
+};
+
+STDROMPICKEXT(kof99sk, kof99sk, neogeo)
+STD_ROM_FN(kof99sk)
+
+struct BurnDriver BurnDrvKof99sk = {
+	"kof99sk", "kof99", "neogeo", NULL, "2025",
+	"The King of Fighters '99 - Millennium Battle (LC+SK, Hack)\0", NULL, "hack (LIY)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof99skRomInfo, kof99skRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+
 // GOTVG Mslug hacks part 2
 
 // Metal Slug (1v2 Mode,Hack)
@@ -21594,11 +21914,11 @@ struct BurnDriver BurnDrvMslug1v2 = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Origins, Hack) - 2025-04-28
+// Metal Slug (Origins, Hack) - 2025-05-02
 // Modified by 合金弹头爱克斯 / CardCaptorSakura
 
 static struct BurnRomInfo mslugdqyRomDesc[] = {
-	{ "201-p1dqy.p1",	0x200000, 0xf50e465c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1dqy.p1",	0x200000, 0xc11b1c34, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -21657,10 +21977,10 @@ struct BurnDriver BurnDrvMslugfc2 = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Origins Random Item, Hack) - 2024-04-15
+// Metal Slug (Origins Random Item, Hack) - 2025-05-21
 
-static struct BurnRomInfo mslugdyf1RomDesc[] = {
-	{ "201-p1dyf1.p1",	0x200000, 0xa0af0bfc, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+static struct BurnRomInfo mslugdyf2RomDesc[] = {
+	{ "201-p1dyf2.p1",	0x200000, 0x708badd1, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -21675,15 +21995,15 @@ static struct BurnRomInfo mslugdyf1RomDesc[] = {
 	{ "201-v2.v2",		0x400000, 0x472cf9db, 5 | BRF_SND },           //  8
 };
 
-STDROMPICKEXT(mslugdyf1, mslugdyf1, neogeo)
-STD_ROM_FN(mslugdyf1)
+STDROMPICKEXT(mslugdyf2, mslugdyf2, neogeo)
+STD_ROM_FN(mslugdyf2)
 
-struct BurnDriver BurnDrvMslugdyf1 = {
-	"mslugdyf1", "mslug", "neogeo", NULL, "2024",
+struct BurnDriver BurnDrvMslugdyf2 = {
+	"mslugdyf2", "mslug", "neogeo", NULL, "2025",
 	"Metal Slug (Origins Random Item, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_RUNGUN, FBF_MSLUG,
-	NULL, mslugdyf1RomInfo, mslugdyf1RomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NULL, mslugdyf2RomInfo, mslugdyf2RomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
@@ -22093,9 +22413,9 @@ struct BurnDriver BurnDrvMslugxcqi = {
 // Metal Slug X (Soldier Version, Hack) - 2025-04-28
 // Modified by ?
 
-static struct BurnRomInfo mslugxsvhRomDesc[] = {
-	{ "250-p1svh.p1",	0x100000, 0x787403ef, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2svh.ep1",	0x800000, 0xbcb02121, 1 | BRF_ESS | BRF_PRG }, //  1
+static struct BurnRomInfo mslugxxbRomDesc[] = {
+	{ "250-p1xb.p1",	0x100000, 0x787403ef, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2xb.ep1",	0x800000, 0xbcb02121, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1.s1",		0x020000, 0xfb6f441d, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -22103,8 +22423,8 @@ static struct BurnRomInfo mslugxsvhRomDesc[] = {
 	{ "250-c2.c2",		0x800000, 0x31679821, 3 | BRF_GRA },           //  4
 	{ "250-c3.c3",		0x800000, 0xfd602019, 3 | BRF_GRA },           //  5
 	{ "250-c4.c4",		0x800000, 0x31354513, 3 | BRF_GRA },           //  6
-	{ "250-c5svh.c5",	0x800000, 0x882f41c7, 3 | BRF_GRA },           //  7
-	{ "250-c6svh.c6",	0x800000, 0x35b5bb3a, 3 | BRF_GRA },           //  8
+	{ "250-c5xb.c5",	0x800000, 0x882f41c7, 3 | BRF_GRA },           //  7
+	{ "250-c6xb.c6",	0x800000, 0x35b5bb3a, 3 | BRF_GRA },           //  8
 
 	{ "250-m1.m1",		0x020000, 0xfd42a842, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
 
@@ -22113,15 +22433,15 @@ static struct BurnRomInfo mslugxsvhRomDesc[] = {
 	{ "250-v3.v3",		0x200000, 0x2ca65102, 5 | BRF_SND },           // 12
 };
 
-STDROMPICKEXT(mslugxsvh, mslugxsvh, neogeo)
-STD_ROM_FN(mslugxsvh)
+STDROMPICKEXT(mslugxxb, mslugxxb, neogeo)
+STD_ROM_FN(mslugxxb)
 
-struct BurnDriver BurnDrvMslugxsvh = {
-	"mslugxsvh", "mslugx", "neogeo", NULL, "2025",
+struct BurnDriver BurnDrvMslugxxb = {
+	"mslugxxb", "mslugx", "neogeo", NULL, "2025",
 	"Metal Slug X (Soldier Version, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
-	NULL, mslugxsvhRomInfo, mslugxsvhRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NULL, mslugxxbRomInfo, mslugxxbRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	mslugxscInit, NeoExit, NeoFrame, NeoRender, mslugxScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -23061,6 +23381,42 @@ struct BurnDriver BurnDrvMslug5cq = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug5cqRomInfo, mslug5cqRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000,	304, 224, 4, 3
+};
+
+// Metal Slug 5 (Random Ammunition, Hack)
+// Modified by ???
+
+static struct BurnRomInfo mslug5ammorRomDesc[] = {
+	{ "268-p1amr.p1",	0x600000, 0x9ba6f532, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	
+	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },           //  1 Text layer tiles
+
+	{ "268-c1d.c1",		0x800000, 0xe8239365, 3 | BRF_GRA },           //  2 Sprite data
+	{ "268-c2d.c2",		0x800000, 0x89b21d4c, 3 | BRF_GRA },           //  3
+	{ "268-c3d.c3",		0x800000, 0x3cda13a0, 3 | BRF_GRA },           //  4
+	{ "268-c4d.c4",		0x800000, 0x9c00160d, 3 | BRF_GRA },           //  5
+	{ "268-c5d.c5",		0x800000, 0x38754256, 3 | BRF_GRA },           //  6
+	{ "268-c6d.c6",		0x800000, 0x59d33e9c, 3 | BRF_GRA },           //  7
+	{ "268-c7d.c7",		0x800000, 0xc9f8c357, 3 | BRF_GRA },           //  8
+	{ "268-c8d.c8",		0x800000, 0xfafc3eb9, 3 | BRF_GRA },           //  9
+
+	{ "268-m1d.m1",		0x080000, 0x39f3cbba, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
+
+	{ "268-v1d.v1",		0x800000, 0x7ff6ca47, 5 | BRF_SND },           // 11 Sound data
+	{ "268-v2d.v2",		0x800000, 0x696cce3b, 5 | BRF_SND },           // 12
+};
+
+STDROMPICKEXT(mslug5ammor, mslug5ammor, neogeo)
+STD_ROM_FN(mslug5ammor)
+
+struct BurnDriver BurnDrvMslug5ammor = {
+	"mslug5ammor", "mslug5", "neogeo", NULL, "2025",
+	"Metal Slug 5 (Random Ammunition, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
+	NULL, mslug5ammorRomInfo, mslug5ammorRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -17384,12 +17384,12 @@ struct BurnDriver BurnDrvSamsho2sp = {
 	0x1000, 320, 224, 4, 3
 };
 
-// Samurai Shodown II Perfect Hack v. 2.1 - 2024-06-26
+// Samurai Shodown II Perfect Hack v. 2.2 - 2024-07-12
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",	0x100000, 0x82ef7872, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "063-p2pe.sp2",	0x100000, 0x48cba9cb, 1 | BRF_ESS | BRF_PRG }, //  1
-	{ "063-p3pe.p3",	0x020000, 0x291dd6de, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
+	{ "063-p1pe.p1",	0x100000, 0x03bfaaaf, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p2pe.sp2",	0x100000, 0xa3a39ea4, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "063-p3pe.p3",	0x020000, 0x82ce7ad7, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	{ "063-s1.s1",		0x020000, 0x64a5cd66, 2 | BRF_GRA },           //  3 Text layer tiles
 
@@ -17415,8 +17415,8 @@ STD_ROM_FN(samsho2pe)
 
 struct BurnDriver BurnDrvSamsho2pe = {
 	"samsho2pe", "samsho2", "neogeo", NULL, "2024",
-	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Perfect V. 2.1, hack)\0", NULL, "Bear", "Neo Geo MVS",
-	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.1, hack)\0", NULL, NULL, NULL,
+	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Perfect V. 2.2, hack)\0", NULL, "Bear", "Neo Geo MVS",
+	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.2, hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
 	NULL, samsho2peRomInfo, samsho2peRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	Samsho2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
@@ -20797,11 +20797,11 @@ struct BurnDriver BurnDrvkf2k3ps2sp = {
  *************************************************************************************/
 
 static struct BurnRomInfo kof94teRomDesc[] = {
-	{ "055-p1te.p1",	0x200000, 0x457d9cf7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "055-p1te.p1",	0x200000, 0xe4d3e394, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "055-s1te.s1",	0x020000, 0xdcd024d2, 2 | BRF_GRA },           //  1 Text layer tiles
 
-	{ "055-c1te.c1",	0x200000, 0xbfa24fad, 3 | BRF_GRA },           //  2 Sprite data
+	{ "055-c1te.c1",	0x200000, 0xdaf4f5d5, 3 | BRF_GRA },           //  2 Sprite data
 	{ "055-c2te.c2",	0x200000, 0x849bdfba, 3 | BRF_GRA },           //  3
 	{ "055-c3.c3",		0x200000, 0x54f66254, 3 | BRF_GRA },           //  4
 	{ "055-c4.c4",		0x200000, 0x0b01765f, 3 | BRF_GRA },           //  5
@@ -20822,7 +20822,7 @@ STD_ROM_FN(kof94te)
 
 struct BurnDriver BurnDrvKof94te = {
 	"kof94te", "kof94", "neogeo", NULL, "2024",
-	"The King of Fighters '94 (Team Edit Edition: KOF95 style portraits v1.4.1, Hack)\0", NULL, "hack (Matt Greer)", "Neo Geo MVS",
+	"The King of Fighters '94 (Team Edit Edition: KOF95 style portraits v1.4.2, Hack)\0", NULL, "hack (Matt Greer)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof94teRomInfo, kof94teRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
@@ -20831,11 +20831,11 @@ struct BurnDriver BurnDrvKof94te = {
 };
 
 static struct BurnRomInfo kof94teaRomDesc[] = {
-	{ "055-p1tea.p1",	0x200000, 0xbcda9e71, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "055-p1tea.p1",	0x200000, 0x26650715, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "055-s1te.s1",	0x020000, 0xdcd024d2, 2 | BRF_GRA },           //  1 Text layer tiles
 
-	{ "055-c1tea.c1",	0x200000, 0xea6d4238, 3 | BRF_GRA },           //  2 Sprite data
+	{ "055-c1tea.c1",	0x200000, 0x8f3bf840, 3 | BRF_GRA },           //  2 Sprite data
 	{ "055-c2tea.c2",	0x200000, 0xf45d317d, 3 | BRF_GRA },           //  3
 	{ "055-c3.c3",		0x200000, 0x54f66254, 3 | BRF_GRA },           //  4
 	{ "055-c4.c4",		0x200000, 0x0b01765f, 3 | BRF_GRA },           //  5
@@ -20856,7 +20856,7 @@ STD_ROM_FN(kof94tea)
 
 struct BurnDriver BurnDrvKof94tea = {
 	"kof94tea", "kof94", "neogeo", NULL, "2024",
-	"The King of Fighters '94 (Team Edit Edition: KOF94 style portraits v1.4.1, Hack)\0", NULL, "hack (Matt Greer)", "Neo Geo MVS",
+	"The King of Fighters '94 (Team Edit Edition: KOF94 style portraits v1.4.2, Hack)\0", NULL, "hack (Matt Greer)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof94teaRomInfo, kof94teaRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -20232,12 +20232,12 @@ struct BurnDriver BurnDrvrbffspbh = {
 	0x1000, 320, 224, 4, 3
 };
 
-// Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer (Eternal, Hack) - 2024-04-11
+// Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer (Eternal, Hack) - 2024-05-23
 // Modified by jlima
 // https://www.ppxclub.com/forum.php?mod=viewthread&tid=724160
 
 static struct BurnRomInfo gowcaietRomDesc[] = {
-	{ "094-p1et.p1",	0x200000, 0xfe5df757, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "094-p1et.p1",	0x200000, 0x4236d373, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "094-s1.s1",		0x020000, 0x2f8748a2, 2 | BRF_GRA },           //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21512,10 +21512,10 @@ struct BurnDriver BurnDrvmslugdqy = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-09-26
+// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-10-14
 
 static struct BurnRomInfo mslugfc2RomDesc[] = {
-	{ "201-p1fc2.p1",	0x200000, 0x42181751, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1fc2.p1",	0x200000, 0xb0b1d11b, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -22636,7 +22636,7 @@ static struct BurnRomInfo mslug5fRomDesc[] = {
 
 	{ "268-m1do.m1",     0x020000, 0x6fa01c9a, 4 | BRF_ESS | BRF_PRG },  // 11 Z80 code
 
-	{ "268-v1d.v1",      0x400000, 0xf61daa9e, 5 | BRF_SND },            // 12 Sound data
+	{ "268-v1nd.v1",     0x400000, 0xf61daa9e, 5 | BRF_SND },            // 12 Sound data
 	{ "268-v2f.v2",      0x400010, 0x7fed45cb, 5 | BRF_SND },            // 13
 	{ "268-v3f.v3",      0x400000, 0xdc737e12, 5 | BRF_SND },            // 14
 	{ "268-v4f.v4",      0x437510, 0xe3a76022, 5 | BRF_SND },            // 15

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21920,11 +21920,11 @@ struct BurnDriver BurnDrvMslug1v2 = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Origins, Hack) - 2025-05-02
+// Metal Slug (Origins, Hack) - 2025-06-06
 // Modified by 合金弹头爱克斯 / CardCaptorSakura
 
 static struct BurnRomInfo mslugdqyRomDesc[] = {
-	{ "201-p1dqy.p1",	0x200000, 0xc11b1c34, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1dqy.p1",	0x200000, 0xee4ec348, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -22375,12 +22375,12 @@ struct BurnDriver BurnDrvMslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire v6.0, Hack) - 2025-04-03
+// Metal Slug X (Legendary Unlimited Fire v6.0, Hack) - 2025-06-09
 // Modified by AKS & SAKURA
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
-	{ "250-p1cqi.p1",	0x100000, 0xb4cc793f, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x800000, 0x93534961, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1cqi.p1",	0x100000, 0xcce1fb1b, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2cqi.ep1",	0x800000, 0x1dca19dd, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -22681,12 +22681,12 @@ struct BurnDriver BurnDrvMslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire v6.0, Hack) - 2025-05-22
+// Metal Slug 3 (Legendary Unlimited Fire v6.0, Hack) - 2025-06-12
 // Modified by AKS
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0x0cf334e4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x800000, 0x65c1ea54, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0x98c63ec0, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x800000, 0x87d0578d, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
@@ -22718,12 +22718,12 @@ struct BurnDriver BurnDrvMslug3cqi = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legend Tower Defense v5.0, Hack) - 2025-05-08
+// Metal Slug 3 (Legend Tower Defense v6.0, Hack) - 2025-06-09
 // Modified by AKS
 
 static struct BurnRomInfo mslug3cqtfbRomDesc[] = {
-	{ "256-ph1cqt.p1",	0x100000, 0x8be75a1e, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
-	{ "256-ph2cqt.sp2",	0x800000, 0xf14fb1ba, 1 | BRF_ESS | BRF_PRG },	//  1 
+	{ "256-ph1cqt.p1",	0x100000, 0x5ae59189, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
+	{ "256-ph2cqt.sp2",	0x800000, 0x50fd39dc, 1 | BRF_ESS | BRF_PRG },	//  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },			//  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },			//  3
@@ -22747,10 +22747,47 @@ STD_ROM_FN(mslug3cqtfb)
 
 struct BurnDriver BurnDrvMslug3cqtfb = {
 	"mslug3cqtfb", "mslug3", "neogeo", NULL, "2024",
-	"Metal Slug 3 (Legend Tower Defense v5.0, Hack)\0", NULL, "hack (AKS)", "Neo Geo MVS",
+	"Metal Slug 3 (Legend Tower Defense v6.0, Hack)\0", NULL, "hack (AKS)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug3cqtfbRomInfo, mslug3cqtfbRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	ngOc400osRhInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+// Metal Slug 3 (Legendary Journey v5.0, Hack) - 2025-06-09
+// Modified by AKS & Sakura
+
+static struct BurnRomInfo mslug3cqztRomDesc[] = {
+	{ "256-ph1cqz.p1",	0x100000, 0x44b4b221, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqz.sp2",	0x800000, 0xa6aecb08, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
+	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
+	{ "256-c3d.c3",		0x800000, 0xbfaade82, 3 | BRF_GRA },           //  4
+	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },           //  5
+	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },           //  6
+	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },           //  7
+	{ "256-c7cqt.c7",	0x800000, 0xac5d0a7e, 3 | BRF_GRA },           //  8
+	{ "256-c8cqt.c8",	0x800000, 0xe0018022, 3 | BRF_GRA },           //  9
+
+	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
+
+	{ "256-v1.v1",		0x400000, 0xf2690241, 5 | BRF_SND },           // 11 Sound data
+	{ "256-v2.v2",		0x400000, 0x7e2a10bd, 5 | BRF_SND },           // 12
+	{ "256-v3.v3",		0x400000, 0x0eaec17c, 5 | BRF_SND },           // 13
+	{ "256-v4.v4",		0x400000, 0x9b4b22d4, 5 | BRF_SND },           // 14
+};
+
+STDROMPICKEXT(mslug3cqzt, mslug3cqzt, neogeo)
+STD_ROM_FN(mslug3cqzt)
+
+struct BurnDriver BurnDrvMslug3cqzt = {
+	"mslug3cqzt", "mslug3", "neogeo", NULL, "2025",
+	"Metal Slug 3 (Legendary Journey v5.0, Hack)\0", NULL, "hack (AKS & Sakura)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
+	NULL, mslug3cqztRomInfo, mslug3cqztRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	ngOc400osRhInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -22867,12 +22904,12 @@ struct BurnDriver BurnDrvMslug4lwq = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 4 (Legendary Unlimited Fire v6.0, Hack) - 2025-04-03
+// Metal Slug 4 (Legendary Unlimited Fire v6.0, Hack) - 2025-06-08
 // Modified by AKS & SAKURA
 
 static struct BurnRomInfo mslug4zjhlRomDesc[] = {
-	{ "263-p1zjh.p1",	0x100000, 0x68e0e022, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2zjh.sp2",	0x800000, 0xeba906ff, 1 | BRF_ESS | BRF_PRG },  //  1
+	{ "263-p1zjh.p1",	0x100000, 0x2ea44ba5, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2zjh.sp2",	0x800000, 0x57d3bd0b, 1 | BRF_ESS | BRF_PRG },  //  1
 	
 	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
 
@@ -23357,11 +23394,11 @@ struct BurnDriver BurnDrvMslug5an = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend v6.0, Hack) - 2025-04-03
+// Metal Slug 5 (The Ultimate Legend v6.0, Hack) - 2025-06-09
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0x8eb713e3, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0x80179a8d, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -20335,7 +20335,7 @@ struct BurnDriver BurnDrvCyborgForce = {
 	0x1000, 320, 224, 4, 3
 };
 
-// YoYo-Shuriken (HB)
+// Yo-Yo Shuriken (HB)
 // https://drludos.itch.io/yo-yo-shuriken-neo-geo
 
 static struct BurnRomInfo yoyoshknRomDesc[] = {
@@ -20934,6 +20934,42 @@ struct BurnDriver BurnDrvkof97evn = {
 	NULL, kof97evnRomInfo, kof97evnRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
+};
+
+// The King of Fighters '97 (Ratio v1.0, Hack)
+// https://romhackplaza.org/romhacks/king-of-fighters-97-arcade/
+
+static struct BurnRomInfo kof97rtoRomDesc[] = {
+	{ "232-p1rto.p1",	0x100000, 0xc7d6c2f0, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "232-p2.sp2",		0x400000, 0x158b23f6, 1 | BRF_ESS | BRF_PRG }, //  1 
+
+	{ "232-s1.s1",		0x020000, 0x8514ecf5, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "232-c1.c1",		0x800000, 0x5f8bf0a1, 3 | BRF_GRA },           //  3 Sprite data
+	{ "232-c2.c2",		0x800000, 0xe4d45c81, 3 | BRF_GRA },           //  4 
+	{ "232-c3.c3",		0x800000, 0x581d6618, 3 | BRF_GRA },           //  5 
+	{ "232-c4.c4",		0x800000, 0x49bb1e68, 3 | BRF_GRA },           //  6 
+	{ "232-c5.c5",		0x400000, 0x34fc4e51, 3 | BRF_GRA },           //  7 
+	{ "232-c6.c6",		0x400000, 0x4ff4d47b, 3 | BRF_GRA },           //  8 
+
+	{ "232-m1.m1",		0x020000, 0x45348747, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+
+	{ "232-v1.v1",		0x400000, 0x22a2b5b5, 5 | BRF_SND },           // 10 Sound data
+	{ "232-v2.v2",		0x400000, 0x2304e744, 5 | BRF_SND },           // 11 
+	{ "232-v3.v3",		0x400000, 0x759eb954, 5 | BRF_SND },           // 12 
+};
+
+STDROMPICKEXT(kof97rto, kof97rto, neogeo)
+STD_ROM_FN(kof97rto)
+
+struct BurnDriver BurnDrvKof97rto = {
+	"kof97rto", "kof97", "neogeo", NULL, "2023",
+	"The King of Fighters '97 (Ratio v1.0, Hack)\0", NULL, "hack (bankbank)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof97rtoRomInfo, kof97rtoRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
 };
 
 // The King of Fighters '97 Super Plus (Hack)

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21508,41 +21508,10 @@ struct BurnDriver BurnDrvmslugdqy = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Random Item, Hack) - 2024-04-15
-
-static struct BurnRomInfo mslugfc1RomDesc[] = {
-	{ "201-p1fc1.p1",	0x200000, 0x3c9029ba, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-
-	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
-
-	{ "201-c1.c1",		0x400000, 0x72813676, 3 | BRF_GRA },           //  2 Sprite data
-	{ "201-c2.c2",		0x400000, 0x96f62574, 3 | BRF_GRA },           //  3
-	{ "201-c3.c3",		0x400000, 0x5121456a, 3 | BRF_GRA },           //  4
-	{ "201-c4.c4",		0x400000, 0xf4ad59a3, 3 | BRF_GRA },           //  5
-
-	{ "201-m1.m1",		0x020000, 0xc28b3253, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
-
-	{ "201-v1.v1",		0x400000, 0x23d22ed1, 5 | BRF_SND },           //  7 Sound data
-	{ "201-v2.v2",		0x400000, 0x472cf9db, 5 | BRF_SND },           //  8
-};
-
-STDROMPICKEXT(mslugfc1, mslugfc1, neogeo)
-STD_ROM_FN(mslugfc1)
-
-struct BurnDriver BurnDrvmslugfc1 = {
-	"mslugfc1", "mslug", "neogeo", NULL, "2024",
-	"Metal Slug (Random Item, Hack)\0", NULL, "hack", "Neo Geo MVS",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_RUNGUN, FBF_MSLUG,
-	NULL, mslugfc1RomInfo, mslugfc1RomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
-	0x1000,	304, 224, 4, 3
-};
-
-// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-04-15
+// Metal Slug (Random Item, Powerful Enemy Defense, Hack) - 2024-08-31
 
 static struct BurnRomInfo mslugfc2RomDesc[] = {
-	{ "201-p1fc2.p1",	0x200000, 0x91b8b63d, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1fc2.p1",	0x200000, 0x273aea46, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -22239,6 +22239,43 @@ struct BurnDriver BurnDrvMslug3cqi = {
 	0x1000, 304, 224, 4, 3
 };
 
+// Metal Slug 3 (Tower Defense, Hack) - 2024-11-21
+// Modified by ?
+
+static struct BurnRomInfo mslug3tdRomDesc[] = {
+	{ "256-ph1td.p1",	0x100000, 0x2fcba62c, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
+	{ "256-ph2td.sp2",	0x800000, 0xbfdebae1, 1 | BRF_ESS | BRF_PRG },	//  1 
+
+	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },			//  2 Sprite data
+	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },			//  3
+	{ "256-c3d.c3",		0x800000, 0xbfaade82, 3 | BRF_GRA },			//  4
+	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },			//  5
+	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },			//  6
+	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },			//  7
+	{ "256-c7td.c7",	0x800000, 0x9fdf02a4, 3 | BRF_GRA },			//  8
+	{ "256-c8td.c8",	0x800000, 0x6449f0c1, 3 | BRF_GRA },			//  9
+
+	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG },	// 10 Z80 code
+
+	{ "256-v1.v1",		0x400000, 0xf2690241, 5 | BRF_SND },			// 11 Sound data
+	{ "256-v2.v2",		0x400000, 0x7e2a10bd, 5 | BRF_SND },			// 12
+	{ "256-v3.v3",		0x400000, 0x0eaec17c, 5 | BRF_SND },			// 13
+	{ "256-v4.v4",		0x400000, 0x9b4b22d4, 5 | BRF_SND },			// 14
+};
+
+STDROMPICKEXT(mslug3td, mslug3td, neogeo)
+STD_ROM_FN(mslug3td)
+
+struct BurnDriver BurnDrvMslug3td = {
+	"mslug3td", "mslug3", "neogeo", NULL, "2024",
+	"Metal Slug 3 (Tower Defense, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
+	NULL, mslug3tdRomInfo, mslug3tdRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	ngOc400osInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
 
 // Metal Slug 4 (Random Ammunition, Hack)
 // Modified by 磁暴线圈

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21931,12 +21931,12 @@ struct BurnDriver BurnDrvmslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-06-21
+// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-07-11
 // Modified by ?
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
-	{ "250-p1cqi.p1",	0x100000, 0xcb971d43, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x400000, 0x756b4ddd, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1cqi.p1",	0x100000, 0xf8f95ffa, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2cqi.ep1",	0x400000, 0x2c36b1a5, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -22193,12 +22193,12 @@ struct BurnDriver BurnDrvmslug3cq = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-06-20
+// Metal Slug 3 (Legendary Unlimited Fire, Hack) - 2024-07-11
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqiRomDesc[] = {
-	{ "256-ph1cqi.p1",	0x100000, 0x1874bf57, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cqi.sp2",	0x400000, 0xe62fc84c, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cqi.p1",	0x100000, 0x18b951c2, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cqi.sp2",	0x400000, 0xd60f631d, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -17384,11 +17384,11 @@ struct BurnDriver BurnDrvSamsho2sp = {
 	0x1000, 320, 224, 4, 3
 };
 
-// Samurai Shodown II Perfect Hack v. 2.2 - 2024-07-12
+// Samurai Shodown II Perfect Hack v. 2.3 - 2024-09-07
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",	0x100000, 0x03bfaaaf, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "063-p2pe.sp2",	0x100000, 0xa3a39ea4, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "063-p1pe.p1",	0x100000, 0x184c3a6c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p2pe.sp2",	0x100000, 0x025ee4ed, 1 | BRF_ESS | BRF_PRG }, //  1
 	{ "063-p3pe.p3",	0x020000, 0x82ce7ad7, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	{ "063-s1.s1",		0x020000, 0x64a5cd66, 2 | BRF_GRA },           //  3 Text layer tiles
@@ -17415,8 +17415,8 @@ STD_ROM_FN(samsho2pe)
 
 struct BurnDriver BurnDrvSamsho2pe = {
 	"samsho2pe", "samsho2", "neogeo", NULL, "2024",
-	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Perfect V. 2.2, hack)\0", NULL, "Bear", "Neo Geo MVS",
-	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.2, hack)\0", NULL, NULL, NULL,
+	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Perfect V. 2.3, hack)\0", NULL, "hack (Bear)", "Neo Geo MVS",
+	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.3, hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
 	NULL, samsho2peRomInfo, samsho2peRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	Samsho2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
@@ -20365,6 +20365,10 @@ struct BurnDriver BurnDrvYoyoshkn = {
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
+
+// ----------
+// Extra Roms
+// ----------
 
 // Metal Slug Unity (Added Timer)
 // Modified by Alice愛麗絲/合金弹头爱克斯/CXZInc

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -1301,7 +1301,7 @@ static struct BurnRomInfo neocdzRomDesc[] = {
 STD_ROM_PICK(neocdz)
 STD_ROM_FN(neocdz)
 
-struct BurnDriver BurnDrvneocdz = {
+struct BurnDriver BurnDrvNeocdz = {
 	"neocdz", NULL, "neogeo", NULL, "1996",
 	"Neo Geo CDZ system\0", "System - media selected seperately", "SNK", "Neo Geo CDZ",
 	NULL, NULL, NULL, NULL,
@@ -2929,7 +2929,7 @@ static struct BurnRomInfo bb2020RomDesc[] = {
 STDROMPICKEXT(bb2020, bb2020, neogeo)
 STD_ROM_FN(bb2020)
 
-struct BurnDriver BurnDrvbb2020 = {
+struct BurnDriver BurnDrv2020bb = {
 	"2020bb", NULL, "neogeo", NULL, "1991",
 	"2020 Super Baseball (set 1)\0", NULL, "SNK / Pallas", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -2962,7 +2962,7 @@ static struct BurnRomInfo bba2020RomDesc[] = {
 STDROMPICKEXT(bba2020, bba2020, neogeo)
 STD_ROM_FN(bba2020)
 
-struct BurnDriver BurnDrvbba2020 = {
+struct BurnDriver BurnDrv2020bba = {
 	"2020bba", "2020bb", "neogeo", NULL, "1991",
 	"2020 Super Baseball (set 2)\0", NULL, "SNK / Pallas", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -2994,7 +2994,7 @@ static struct BurnRomInfo bbh2020RomDesc[] = {
 STDROMPICKEXT(bbh2020, bbh2020, neogeo)
 STD_ROM_FN(bbh2020)
 
-struct BurnDriver BurnDrvbbh2020 = {
+struct BurnDriver BurnDrv2020bbh = {
 	"2020bbh", "2020bb", "neogeo", NULL, "1991",
 	"2020 Super Baseball (set 3)\0", NULL, "SNK / Pallas", "Neo Geo AES",
 	NULL, NULL, NULL, NULL,
@@ -3157,7 +3157,7 @@ static struct BurnRomInfo fatfury1RomDesc[] = {
 STDROMPICKEXT(fatfury1, fatfury1, neogeo)
 STD_ROM_FN(fatfury1)
 
-struct BurnDriver BurnDrvFatFury1 = {
+struct BurnDriver BurnDrvFatfury1 = {
 	"fatfury1", NULL, "neogeo", NULL, "1992",
 	"Fatal Fury - King of Fighters / Garou Densetsu - shukumei no tatakai (NGM-033)(NGH-033)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Fatal Fury - King of Fighters\0\u9913\u72FC\u4F1D\u8AAC - \u5BBF\u547D\u306E\u95D8\u3044 (NGM-033)(NGH-033)\0", NULL, NULL, NULL,
@@ -3576,7 +3576,7 @@ static struct BurnRomInfo samshohRomDesc[] = {
 STDROMPICKEXT(samshoh, samshoh, neogeo)
 STD_ROM_FN(samshoh)
 
-struct BurnDriver BurnDrvSamShoh = {
+struct BurnDriver BurnDrvSamshoh = {
 	"samshoh", "samsho", "neogeo", NULL, "1993",
 	"Samurai Shodown / Samurai Spirits (NGH-045)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -3615,7 +3615,7 @@ static struct BurnRomInfo tophuntrRomDesc[] = {
 STDROMPICKEXT(tophuntr, tophuntr, neogeo)
 STD_ROM_FN(tophuntr)
 
-struct BurnDriver BurnDrvtophntr = {
+struct BurnDriver BurnDrvTophuntr = {
 	"tophuntr", NULL, "neogeo", NULL, "1994",
 	"Top Hunter - Roddy & Cathy (NGM-046)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -3654,7 +3654,7 @@ static struct BurnRomInfo tophuntrhRomDesc[] = {
 STDROMPICKEXT(tophuntrh, tophuntrh, neogeo)
 STD_ROM_FN(tophuntrh)
 
-struct BurnDriver BurnDrvtophntrh = {
+struct BurnDriver BurnDrvTophuntrh = {
 	"tophuntrh", "tophuntr", "neogeo", NULL, "1994",
 	"Top Hunter - Roddy & Cathy (NGH-046)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -4324,7 +4324,7 @@ static INT32 samsho2kInit()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvsamsho2k = {
+struct BurnDriver BurnDrvSamsho2k = {
 	"samsho2k", "samsho2", "neogeo", NULL, "1994",
 	"Saulabi Spirits / Jin Saulabi Tu Hon (Korean release of Samurai Shodown II)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -4363,7 +4363,7 @@ static struct BurnRomInfo samsho2kaRomDesc[] = {
 STDROMPICKEXT(samsho2ka, samsho2ka, neogeo)
 STD_ROM_FN(samsho2ka)
 
-struct BurnDriver BurnDrvsamsho2ka = {
+struct BurnDriver BurnDrvSamsho2ka = {
 	"samsho2ka", "samsho2", "neogeo", NULL, "1994",
 	"Saulabi Spirits / Jin Saulabi Tu Hon (Korean release of Samurai Shodown II, set 2)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -4596,7 +4596,7 @@ static struct BurnRomInfo samsho3RomDesc[] = {
 STDROMPICKEXT(samsho3, samsho3, neogeo)
 STD_ROM_FN(samsho3)
 
-struct BurnDriver BurnDrvSamSho3 = {
+struct BurnDriver BurnDrvSamsho3 = {
 	"samsho3", NULL, "neogeo", NULL, "1995",
 	"Samurai Shodown III / Samurai Spirits - Zankurou Musouken (NGM-087)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Samurai Shodown III\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4 - \u65AC\u7D05\u90CE\u7121\u53CC\u5263 (NGM-087)\0", NULL, NULL, NULL,
@@ -4633,7 +4633,7 @@ static struct BurnRomInfo samsho3hRomDesc[] = {
 STDROMPICKEXT(samsho3h, samsho3h, neogeo)
 STD_ROM_FN(samsho3h)
 
-struct BurnDriver BurnDrvSamSho3h = {
+struct BurnDriver BurnDrvSamsho3h = {
 	"samsho3h", "samsho3", "neogeo", NULL, "1995",
 	"Samurai Shodown III / Samurai Spirits - Zankurou Musouken (NGH-087)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Samurai Shodown III\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4 - \u65AC\u7D05\u90CE\u7121\u53CC\u5263 (NGH-087)\0", NULL, NULL, NULL,
@@ -4670,7 +4670,7 @@ static struct BurnRomInfo fswordsRomDesc[] = {
 STDROMPICKEXT(fswords, fswords, neogeo)
 STD_ROM_FN(fswords)
 
-struct BurnDriver BurnDrvfswords = {
+struct BurnDriver BurnDrvFswords = {
 	"fswords", "samsho3", "neogeo", NULL, "1995",
 	"Fighters Swords (Korean release of Samurai Shodown III)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -4708,7 +4708,7 @@ static struct BurnRomInfo rbff1RomDesc[] = {
 STDROMPICKEXT(rbff1, rbff1, neogeo)
 STD_ROM_FN(rbff1)
 
-struct BurnDriver BurnDrvrbff1 = {
+struct BurnDriver BurnDrvRbff1 = {
 	"rbff1", NULL, "neogeo", NULL, "1995",
 	"Real Bout Fatal Fury / Real Bout Garou Densetsu (NGM-095)(NGH-095)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Real Bout Fatal Fury\0Real Bout \u9913\u72FC\u4F1D\u8AAC (NGM-095)(NGH-095)\0", NULL, NULL, NULL,
@@ -4764,7 +4764,7 @@ static INT32 rbff1aInit()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvrbff1a = {
+struct BurnDriver BurnDrvRbff1a = {
 	"rbff1a", "rbff1", "neogeo", NULL, "1995",
 	"Real Bout Fatal Fury / Real Bout Garou Densetsu (bug fix revision)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Real Bout Fatal Fury\0Real Bout \u9913\u72FC\u4F1D\u8AAC (bug fix revision)\0", NULL, NULL, NULL,
@@ -4802,7 +4802,7 @@ static struct BurnRomInfo rbff1kRomDesc[] = {
 STDROMPICKEXT(rbff1k, rbff1k, neogeo)
 STD_ROM_FN(rbff1k)
 
-struct BurnDriver BurnDrvrbff1k = {
+struct BurnDriver BurnDrvRbff1k = {
 	"rbff1k", "rbff1", "neogeo", NULL, "1995",
 	"Real Bout Fatal Fury / Real Bout Garou Densetsu (Korean release)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Real Bout Fatal Fury\0Real Bout \u9913\u72FC\u4F1D\u8AAC (Korean release)\0", NULL, NULL, NULL,
@@ -4844,7 +4844,7 @@ static struct BurnRomInfo rbff1kaRomDesc[] = {
 STDROMPICKEXT(rbff1ka, rbff1ka, neogeo)
 STD_ROM_FN(rbff1ka)
 
-struct BurnDriver BurnDrvrbff1ka = {
+struct BurnDriver BurnDrvRbff1ka = {
 	"rbff1ka", "rbff1", "neogeo", NULL, "1995",
 	"Real Bout Fatal Fury / Real Bout Garou Densetsu (Korean release, bug fix revision)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Real Bout Fatal Fury\0Real Bout \u9913\u72FC\u4F1D\u8AAC (Korean release, bug fix revision)\0", NULL, NULL, NULL,
@@ -5103,7 +5103,7 @@ static struct BurnRomInfo samsho4RomDesc[] = {
 STDROMPICKEXT(samsho4, samsho4, neogeo)
 STD_ROM_FN(samsho4)
 
-struct BurnDriver BurnDrvSamSho4 = {
+struct BurnDriver BurnDrvSamsho4 = {
 	"samsho4", NULL, "neogeo", NULL, "1996",
 	"Samurai Shodown IV - Amakusa's Revenge / Samurai Spirits - Amakusa Kourin (NGM-222)(NGH-222)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Samurai Shodown IV - Amakusa's Revenge\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4 - \u5929\u8349\u964D\u81E8 (NGM-222)(NGH-222)\0", NULL, NULL, NULL,
@@ -5141,7 +5141,7 @@ static struct BurnRomInfo samsho4kRomDesc[] = {
 STDROMPICKEXT(samsho4k, samsho4k, neogeo)
 STD_ROM_FN(samsho4k)
 
-struct BurnDriver BurnDrvSamSho4k = {
+struct BurnDriver BurnDrvSamsho4k = {
 	"samsho4k", "samsho4", "neogeo", NULL, "1996",
 	"Pae Wang Jeon Seol / Legend of a Warrior (Korean censored Samurai Shodown IV)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5178,7 +5178,7 @@ static struct BurnRomInfo rbffspecRomDesc[] = {
 STDROMPICKEXT(rbffspec, rbffspec, neogeo)
 STD_ROM_FN(rbffspec)
 
-struct BurnDriver BurnDrvrbffspec = {
+struct BurnDriver BurnDrvRbffspec = {
 	"rbffspec", NULL, "neogeo", NULL, "1996",
 	"Real Bout Fatal Fury Special / Real Bout Garou Densetsu Special\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5217,7 +5217,7 @@ static struct BurnRomInfo rbffspeckRomDesc[] = {
 STDROMPICKEXT(rbffspeck, rbffspeck, neogeo)
 STD_ROM_FN(rbffspeck)
 
-struct BurnDriver BurnDrvrbffspeck = {
+struct BurnDriver BurnDrvRbffspeck = {
 	"rbffspeck", "rbffspec", "neogeo", NULL, "1996",
 	"Real Bout Fatal Fury Special / Real Bout Garou Densetsu Special (Korean release)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5537,7 +5537,7 @@ static struct BurnRomInfo lastbladRomDesc[] = {
 STDROMPICKEXT(lastblad, lastblad, neogeo)
 STD_ROM_FN(lastblad)
 
-struct BurnDriver BurnDrvlastblad = {
+struct BurnDriver BurnDrvLastblad = {
 	"lastblad", NULL, "neogeo", NULL, "1997",
 	"The Last Blade / Bakumatsu Roman - Gekka no Kenshi (NGM-2340)\0", NULL, "SNK", "Neo Geo MVS",
 	L"The Last Blade\0\u5E55\u672B\u6D6A\u6F2B \u6708\u83EF\u306E\u5263\u58EB (NGM-2340)\0", NULL, NULL, NULL,
@@ -5574,7 +5574,7 @@ static struct BurnRomInfo lastbladhRomDesc[] = {
 STDROMPICKEXT(lastbladh, lastbladh, neogeo)
 STD_ROM_FN(lastbladh)
 
-struct BurnDriver BurnDrvlastbladh = {
+struct BurnDriver BurnDrvLastbladh = {
 	"lastbladh", "lastblad", "neogeo", NULL, "1997",
 	"The Last Blade / Bakumatsu Roman - Gekka no Kenshi (NGH-2340)\0", NULL, "SNK", "Neo Geo AES",
 	L"The Last Blade\0\u5E55\u672B\u6D6A\u6F2B \u6708\u83EF\u306E\u5263\u58EB (NGH-2340)\0", NULL, NULL, NULL,
@@ -5611,7 +5611,7 @@ static struct BurnRomInfo lastsoldRomDesc[] = {
 STDROMPICKEXT(lastsold, lastsold, neogeo)
 STD_ROM_FN(lastsold)
 
-struct BurnDriver BurnDrvlastsold = {
+struct BurnDriver BurnDrvLastsold = {
 	"lastsold", "lastblad", "neogeo", NULL, "1997",
 	"The Last Soldier (Korean release of The Last Blade)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5678,7 +5678,7 @@ static struct BurnRomInfo rbff2RomDesc[] = {
 STDROMPICKEXT(rbff2, rbff2, neogeo)
 STD_ROM_FN(rbff2)
 
-struct BurnDriver BurnDrvrbff2 = {
+struct BurnDriver BurnDrvRbff2 = {
 	"rbff2", NULL, "neogeo", NULL, "1998",
 	"Real Bout Fatal Fury 2 - The Newcomers / Real Bout Garou Densetsu 2 - the newcomers (NGM-2400)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Real Bout Fatal Fury 2 - The Newcomers\0Real Bout \u9913\u72FC\u4F1D\u8AAC\uFF12 (NGM-2400)\0", NULL, NULL, NULL,
@@ -5715,7 +5715,7 @@ static struct BurnRomInfo rbff2hRomDesc[] = {
 STDROMPICKEXT(rbff2h, rbff2h, neogeo)
 STD_ROM_FN(rbff2h)
 
-struct BurnDriver BurnDrvrbff2h = {
+struct BurnDriver BurnDrvRbff2h = {
 	"rbff2h", "rbff2", "neogeo", NULL, "1998",
 	"Real Bout Fatal Fury 2 - The Newcomers / Real Bout Garou Densetsu 2 - the newcomers (NGH-2400)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Real Bout Fatal Fury 2 - The Newcomers\0Real Bout \u9913\u72FC\u4F1D\u8AAC\uFF12 (NGH-2400)\0", NULL, NULL, NULL,
@@ -5752,7 +5752,7 @@ static struct BurnRomInfo rbff2kRomDesc[] = {
 STDROMPICKEXT(rbff2k, rbff2k, neogeo)
 STD_ROM_FN(rbff2k)
 
-struct BurnDriver BurnDrvrbff2k = {
+struct BurnDriver BurnDrvRbff2k = {
 	"rbff2k", "rbff2", "neogeo", NULL, "1998",
 	"Real Bout Fatal Fury 2 - The Newcomers (Korean release)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5794,7 +5794,7 @@ static struct BurnRomInfo mslug2RomDesc[] = {
 STDROMPICKEXT(mslug2, mslug2, neogeo)
 STD_ROM_FN(mslug2)
 
-struct BurnDriver BurnDrvMSlug2 = {
+struct BurnDriver BurnDrvMslug2 = {
 	"mslug2", NULL, "neogeo", NULL, "1998",
 	"Metal Slug 2 - Super Vehicle-001/II (NGM-2410 ~ NGH-2410)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5827,7 +5827,7 @@ static struct BurnRomInfo mslug2fmRomDesc[] = {
 STDROMPICKEXT(mslug2fm, mslug2fm, neogeo)
 STD_ROM_FN(mslug2fm)
 
-struct BurnDriver BurnDrvMSlug2fm = {
+struct BurnDriver BurnDrvMslug2fm = {
 	"mslug2fm", "mslug2", "neogeo", NULL, "2015",
 	"Metal Slug 2 (Friendly Fire FC2, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5860,7 +5860,7 @@ static struct BurnRomInfo mslug2rRomDesc[] = {
 STDROMPICKEXT(mslug2r, mslug2r, neogeo)
 STD_ROM_FN(mslug2r)
 
-struct BurnDriver BurnDrvMSlug2r = {
+struct BurnDriver BurnDrvMslug2r = {
 	"mslug2r", "mslug2", "neogeo", NULL, "2015",
 	"Metal Slug 2 (Enemy Remix, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -5893,7 +5893,7 @@ static struct BurnRomInfo mslug2ctRomDesc[] = {
 STDROMPICKEXT(mslug2ct, mslug2ct, neogeo)
 STD_ROM_FN(mslug2ct)
 
-struct BurnDriver BurnDrvMSlug2ct = {
+struct BurnDriver BurnDrvMslug2ct = {
 	"mslug2ct", "mslug2", "neogeo", NULL, "2015",
 	"Metal Slug 2 (Survival, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6121,7 +6121,7 @@ static struct BurnRomInfo kof98bc2ndRomDesc[] = {
 STDROMPICKEXT(kof98bc2nd, kof98bc2nd, neogeo)
 STD_ROM_FN(kof98bc2nd)
 
-struct BurnDriver BurnDrvkof98bc2nd = {
+struct BurnDriver BurnDrvKof98bc2nd = {
 	"kof98bc2nd", "kof98", "neogeo", NULL, "2020",
 	"The King of Fighters '98 BC 2nd Impact Edition (Hack, Ver.2020-07-29)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6277,7 +6277,7 @@ static struct BurnRomInfo lastbld2RomDesc[] = {
 STDROMPICKEXT(lastbld2, lastbld2, neogeo)
 STD_ROM_FN(lastbld2)
 
-struct BurnDriver BurnDrvlastbld2 = {
+struct BurnDriver BurnDrvLastbld2 = {
 	"lastbld2", NULL, "neogeo", NULL, "1998",
 	"The Last Blade 2 / Bakumatsu Roman - Dai Ni Maku Gekka no Kenshi (NGM-2430)(NGH-2430)\0", NULL, "SNK", "Neo Geo MVS",
 	L"The Last Blade 2\0\u5E55\u672B\u6D6A\u6F2B\u7B2C\u4E8C\u5E55 - \u6708\u83EF\u306E\u5263\u58EB - \u6708\u306B\u54B2\u304F\u83EF\u3001\u6563\u308A\u3086\u304F\u82B1 (NGM-2430)(NGH-2430)\0", NULL, NULL, NULL,
@@ -6470,7 +6470,7 @@ static INT32 mslugxScan(INT32 nAction, INT32 *pnMin)
 	return NeoScan(nAction,pnMin);
 }
 
-struct BurnDriver BurnDrvMSlugx = {
+struct BurnDriver BurnDrvMslugx = {
 	"mslugx", NULL, "neogeo", NULL, "1999",
 	"Metal Slug X - Super Vehicle-001 (NGM-2500 ~ NGH-2500)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6506,7 +6506,7 @@ static struct BurnRomInfo mslugxebRomDesc[] = {
 STDROMPICKEXT(mslugxeb, mslugxeb, neogeo)
 STD_ROM_FN(mslugxeb)
 
-struct BurnDriver BurnDrvMSlugXeb = {
+struct BurnDriver BurnDrvMslugxeb = {
 	"mslugxeb", "mslugx", "neogeo", NULL, "2016",
 	"Metal Slug X (Extreme Blue, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6542,7 +6542,7 @@ static struct BurnRomInfo mslugxlbRomDesc[] = {
 STDROMPICKEXT(mslugxlb, mslugxlb, neogeo)
 STD_ROM_FN(mslugxlb)
 
-struct BurnDriver BurnDrvMSlugXlb = {
+struct BurnDriver BurnDrvMslugxlb = {
 	"mslugxlb", "mslugx", "neogeo", NULL, "2015",
 	"Metal Slug X (Extreme Space, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6578,7 +6578,7 @@ static struct BurnRomInfo mslugxc2RomDesc[] = {
 STDROMPICKEXT(mslugxc2, mslugxc2, neogeo)
 STD_ROM_FN(mslugxc2)
 
-struct BurnDriver BurnDrvMSlugXc2 = {
+struct BurnDriver BurnDrvMslugxc2 = {
 	"mslugxc2", "mslugx", "neogeo", NULL, "2013",
 	"Metal Slug X (Enemy Remix, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6614,7 +6614,7 @@ static struct BurnRomInfo mslugxsrfRomDesc[] = {
 STDROMPICKEXT(mslugxsrf, mslugxsrf, neogeo)
 STD_ROM_FN(mslugxsrf)
 
-struct BurnDriver BurnDrvMSlugXsrf = {
+struct BurnDriver BurnDrvMslugxsrf = {
 	"mslugxsrf", "mslugx", "neogeo", NULL, "2021",
 	"Metal Slug X (AzStar Soda Remix FC2, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6712,7 +6712,7 @@ static INT32 kof99Init()
 	return NeoSMAInit(kof99SMADecrypt, kof99WriteWordBankswitch, 0x2FFFF8, 0x2FFFFA);
 }
 
-struct BurnDriver BurnDrvkof99 = {
+struct BurnDriver BurnDrvKof99 = {
 	"kof99", NULL, "neogeo", NULL, "1999",
 	"The King of Fighters '99 - Millennium Battle (NGM-2510)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6752,7 +6752,7 @@ static struct BurnRomInfo kof99hRomDesc[] = {
 STDROMPICKEXT(kof99h, kof99h, neogeo)
 STD_ROM_FN(kof99h)
 
-struct BurnDriver BurnDrvkof99h = {
+struct BurnDriver BurnDrvKof99h = {
 	"kof99h", "kof99", "neogeo", NULL, "1999",
 	"The King of Fighters '99 - Millennium Battle (NGH-2510)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6795,7 +6795,7 @@ static struct BurnRomInfo kof99eRomDesc[] = {
 STDROMPICKEXT(kof99e, kof99e, neogeo)
 STD_ROM_FN(kof99e)
 
-struct BurnDriver BurnDrvkof99e = {
+struct BurnDriver BurnDrvKof99e = {
 	"kof99e", "kof99", "neogeo", NULL, "1999",
 	"The King of Fighters '99 - Millennium Battle (earlier)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6835,7 +6835,7 @@ static struct BurnRomInfo kof99kRomDesc[] = {
 STDROMPICKEXT(kof99k, kof99k, neogeo)
 STD_ROM_FN(kof99k)
 
-struct BurnDriver BurnDrvkof99k = {
+struct BurnDriver BurnDrvKof99k = {
 	"kof99k", "kof99", "neogeo", NULL, "1999",
 	"The King of Fighters '99 - Millennium Battle (Korean release)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6880,7 +6880,7 @@ INT32 kof99kaInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkof99ka = {
+struct BurnDriver BurnDrvKof99ka = {
 	"kof99ka", "kof99", "neogeo", NULL, "1999",
 	"The King of Fighters '99 - Millennium Battle (Korean release, non-encrypted program)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -6922,7 +6922,7 @@ static struct BurnRomInfo kof99pRomDesc[] = {
 STDROMPICKEXT(kof99p, kof99p, neogeo)
 STD_ROM_FN(kof99p)
 
-struct BurnDriver BurnDrvkof99p = {
+struct BurnDriver BurnDrvKof99p = {
 	"kof99p", "kof99", "neogeo", NULL, "1999",
 	"The King of Fighters '99 - Millennium Battle (prototype)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7132,7 +7132,7 @@ static INT32 garouhInit()
 	return NeoSMAInit(garouhSMADecrypt, garouhWriteWordBankswitch, 0x2FFFCC, 0x2FFFF0);
 }
 
-struct BurnDriver BurnDrvgarouh = {
+struct BurnDriver BurnDrvGarouh = {
 	"garouh", "garou", "neogeo", NULL, "1999",
 	"Garou - Mark of the Wolves (NGM-2530) (NGH-2530)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Garou\0\u9913\u72FC - mark of the wolves (NGM-2530) (NGH-2530)\0", NULL, NULL, NULL,
@@ -7175,7 +7175,7 @@ static struct BurnRomInfo garouhaRomDesc[] = {
 STDROMPICKEXT(garouha, garouha, neogeo)
 STD_ROM_FN(garouha)
 
-struct BurnDriver BurnDrvgarouha = {
+struct BurnDriver BurnDrvGarouha = {
 	"garouha", "garou", "neogeo", NULL, "1999",
 	"Garou - Mark of the Wolves (NGH-2530)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Garou\0\u9913\u72FC - mark of the wolves (NGH-2530)\0", NULL, NULL, NULL,
@@ -7268,7 +7268,7 @@ static INT32 garoublInit()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvgaroubl = {
+struct BurnDriver BurnDrvGaroubl = {
 	"garoubl", "garou", "neogeo", NULL, "1999",
 	"Garou - Mark of the Wolves (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	L"Garou\0\u9913\u72FC - mark of the wolves (bootleg)\0", NULL, NULL, NULL,
@@ -7374,7 +7374,7 @@ static INT32 mslug3Init()
 	return NeoSMAInit(mslug3SMADecrypt, mslug3WriteWordBankswitch, 0, 0);
 }
 
-struct BurnDriver BurnDrvmslug3 = {
+struct BurnDriver BurnDrvMslug3 = {
 	"mslug3", NULL, "neogeo", NULL, "2000",
 	"Metal Slug 3 (NGM-2560)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7476,7 +7476,7 @@ static INT32 mslug3aInit()
 	return NeoSMAInit(mslug3aSMADecrypt, mslug3aWriteWordBankswitch, 0, 0);
 }
 
-struct BurnDriver BurnDrvmslug3a = {
+struct BurnDriver BurnDrvMslug3a = {
 	"mslug3a", "mslug3", "neogeo", NULL, "2000",
 	"Metal Slug 3 (NGM-2560, earlier)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7521,7 +7521,7 @@ static INT32 mslug3hInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvmslug3h = {
+struct BurnDriver BurnDrvMslug3h = {
 	"mslug3h", "mslug3", "neogeo", NULL, "2000",
 	"Metal Slug 3 (NGH-2560)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7574,7 +7574,7 @@ static INT32 mslug3b6Init()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvmslug3b6 = {
+struct BurnDriver BurnDrvMslug3b6 = {
 	"mslug3b6", "mslug3", "neogeo", NULL, "2000",
 	"Metal Slug 6 (Metal Slug 3 bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7672,7 +7672,7 @@ static INT32 kof2000Init()
 	return NeoSMAInit(kof2000SMADecrypt, kof2000WriteWordBankswitch, 0x2FFFD8, 0x2FFFDA);
 }
 
-struct BurnDriver BurnDrvkof2000 = {
+struct BurnDriver BurnDrvKof2000 = {
 	"kof2000", NULL, "neogeo", NULL, "2000",
 	"The King of Fighters 2000 (NGM-2570) (NGH-2570)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7717,7 +7717,7 @@ static INT32 kof2000nInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkof2000n = {
+struct BurnDriver BurnDrvKof2000n = {
 	"kof2000n", "kof2000", "neogeo", NULL, "2000",
 	"The King of Fighters 2000 (not encrypted)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7870,7 +7870,7 @@ static INT32 kof2001Init()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkof2001 = {
+struct BurnDriver BurnDrvKof2001 = {
 	"kof2001", NULL, "neogeo", NULL, "2001",
 	"The King of Fighters 2001 (NGM-262?)\0", NULL, "SNK / Eolith", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -7909,7 +7909,7 @@ static struct BurnRomInfo kof2001hRomDesc[] = {
 STDROMPICKEXT(kof2001h, kof2001h, neogeo)
 STD_ROM_FN(kof2001h)
 
-struct BurnDriver BurnDrvkof2001h = {
+struct BurnDriver BurnDrvKof2001h = {
 	"kof2001h", "kof2001", "neogeo", NULL, "2001",
 	"The King of Fighters 2001 (NGH-2621)\0", NULL, "SNK / Eolith", "Neo Geo AES",
 	NULL, NULL, NULL, NULL,
@@ -7948,7 +7948,7 @@ static struct BurnRomInfo kof2001ruRomDesc[] = {
 STDROMPICKEXT(kof2001ru, kof2001ru, neogeo)
 STD_ROM_FN(kof2001ru)
 
-struct BurnDriver BurnDrvkof2001ru = {
+struct BurnDriver BurnDrvKof2001ru = {
 	"kof2001ru", "kof2001", "neogeo", NULL, "Version 2004-05-07",
 	"The King of Fighters 2001 Remix Ultra 2.3 (Hack By Jason FGCH)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8087,7 +8087,7 @@ static INT32 cthd2003Init()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvcthd2003 = {
+struct BurnDriver BurnDrvCthd2003 = {
 	"cthd2003", "kof2001", "neogeo", NULL, "2003",
 	"Crouching Tiger Hidden Dragon 2003 (set 1)\0", "Hack of \"The King of Fighters 2001\"", "Phenixsoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8165,7 +8165,7 @@ static INT32 ct2k3spInit()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvct2k3sp = {
+struct BurnDriver BurnDrvCt2k3sp = {
 	"ct2k3sp", "kof2001", "neogeo", NULL, "2003",
 	"Crouching Tiger Hidden Dragon 2003 Super Plus\0", NULL, "bootleg", "Neo Geo MVS",
 	L"Crouching Tiger Hidden Dragon 2003 Super Plus\0\u81E5\u864E\u85CF\u9F8D\0", NULL, NULL, NULL,
@@ -8211,7 +8211,7 @@ static INT32 ct2k3saInit()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvct2k3sa = {
+struct BurnDriver BurnDrvCt2k3sa = {
 	"ct2k3sa", "kof2001", "neogeo", NULL, "2003",
 	"Crouching Tiger Hidden Dragon 2003 Super Plus alternate\0", NULL, "bootleg", "Neo Geo MVS",
 	L"Crouching Tiger Hidden Dragon 2003 Super Plus (alternate set)\0\u81E5\u864E\u85CF\u9F8D\0", NULL, NULL, NULL,
@@ -8268,7 +8268,7 @@ static INT32 kof2002Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof2002 = {
+struct BurnDriver BurnDrvKof2002 = {
 	"kof2002", NULL, "neogeo", NULL, "2002",
 	"The King of Fighters 2002 (NGM-2650)(NGH-2650)\0", NULL, "Eolith / Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8357,7 +8357,7 @@ static INT32 kof2002bInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof2002b = {
+struct BurnDriver BurnDrvKof2002b = {
 	"kof2002b", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 2002 (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8393,7 +8393,7 @@ static struct BurnRomInfo kf2k2plsRomDesc[] = {
 STDROMPICKEXT(kf2k2pls, kf2k2pls, neogeo)
 STD_ROM_FN(kf2k2pls)
 
-struct BurnDriver BurnDrvkf2k2pls = {
+struct BurnDriver BurnDrvKf2k2pls = {
 	"kf2k2pls", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 2002 Plus (bootleg set 1)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8430,7 +8430,7 @@ static struct BurnRomInfo kf2k2plaRomDesc[] = {
 STDROMPICKEXT(kf2k2pla, kf2k2pla, neogeo)
 STD_ROM_FN(kf2k2pla)
 
-struct BurnDriver BurnDrvkf2k2pla = {
+struct BurnDriver BurnDrvKf2k2pla = {
 	"kf2k2pla", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 2002 Plus (bootleg set 2)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8496,7 +8496,7 @@ static INT32 kf2k2mpInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkf2k2mp = {
+struct BurnDriver BurnDrvKf2k2mp = {
 	"kf2k2mp", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 2002 Magic Plus (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8560,7 +8560,7 @@ static INT32 kof2km2Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkf2k2mp2 = {
+struct BurnDriver BurnDrvKf2k2mp2 = {
 	"kf2k2mp2", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 2002 Magic Plus II (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8747,7 +8747,7 @@ static INT32 kof10thInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof10th = {
+struct BurnDriver BurnDrvKof10th = {
 	"kof10th", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 10th Anniversary (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8831,7 +8831,7 @@ static INT32 kf10thepInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkf10thep = {
+struct BurnDriver BurnDrvKf10thep = {
 	"kf10thep", "kof2002", "neogeo", NULL, "2005",
 	"The King of Fighters 10th Anniversary Extra Plus (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8906,7 +8906,7 @@ static INT32 kf2k5uniInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkf2k5uni = {
+struct BurnDriver BurnDrvKf2k5uni = {
 	"kf2k5uni", "kof2002", "neogeo", NULL, "2004",
 	"The King of Fighters 10th Anniversary 2005 Unique (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -8967,7 +8967,7 @@ static INT32 kof2k4seInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkof2k4se = {
+struct BurnDriver BurnDrvKof2k4se = {
 	"kof2k4se", "kof2002", "neogeo", NULL, "2004",
 	"The King of Fighters Special Edition 2004 (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9060,7 +9060,7 @@ static INT32 mslug5Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvmslug5 = {
+struct BurnDriver BurnDrvMslug5 = {
 	"mslug5", NULL, "neogeo", NULL, "2003",
 	"Metal Slug 5 (NGM-2680)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9103,7 +9103,7 @@ static struct BurnRomInfo mslug5hRomDesc[] = {
 STDROMPICKEXT(mslug5h, mslug5h, neogeo)
 STD_ROM_FN(mslug5h)
 
-struct BurnDriver BurnDrvmslug5h = {
+struct BurnDriver BurnDrvMslug5h = {
 	"mslug5h", "mslug5", "neogeo", NULL, "2003",
 	"Metal Slug 5 (NGH-2680)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9132,7 +9132,7 @@ static struct BurnRomInfo ms5pcbRomDesc[] = {
 STDROMPICKEXT(ms5pcb, ms5pcb, ms5pcbBIOS)
 STD_ROM_FN(ms5pcb)
 
-struct BurnDriver BurnDrvms5pcb = {
+struct BurnDriver BurnDrvMs5pcb = {
 	"ms5pcb", NULL, NULL, NULL, "2003",
 	"Metal Slug 5 (JAMMA PCB)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9208,7 +9208,7 @@ static INT32 ms5plusInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvms5plus = {
+struct BurnDriver BurnDrvMs5plus = {
 	"ms5plus", "mslug5", "neogeo", NULL, "2003",
 	"Metal Slug 5 Plus (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9218,7 +9218,7 @@ struct BurnDriver BurnDrvms5plus = {
 	0x1000,	304, 224, 4, 3
 };
 
-// SNK vs. Capcom - SVC Chaos (JAMMA PCB, set 1)
+// SNK vs. Capcom - SVC Chaos (JAMMA PCB, NEO-MVH MVO PCB)
 
 static struct BurnRomInfo svcpcbRomDesc[] = {
 	{ "269-p1.p1",    0x2000000, 0x432cfdfc, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
@@ -9291,9 +9291,9 @@ static INT32 svcpcbInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsvcpcb = {
+struct BurnDriver BurnDrvSvcpcb = {
 	"svcpcb", NULL, NULL, NULL, "2003",
-	"SNK vs. Capcom - SVC Chaos (JAMMA PCB, set 1)\0", NULL, "SNK Playmore", "Neo Geo MVS",
+	"SNK vs. Capcom - SVC Chaos (JAMMA PCB, NEO-MVH MVO PCB)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HISCORE_SUPPORTED, 2, HARDWARE_SNK_DEDICATED_PCB | HARDWARE_SNK_CMC50 | HARDWARE_SNK_ALTERNATE_TEXT | HARDWARE_SNK_ENCRYPTED_M1, GBF_VSFIGHT, FBF_KOF | FBF_SF,
 	NULL, svcpcbRomInfo, svcpcbRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, svcpcbDIPInfo,
@@ -9301,7 +9301,7 @@ struct BurnDriver BurnDrvsvcpcb = {
 	0x1000,	304, 224, 4, 3
 };
 
-// SNK vs. Capcom - SVC Chaos (JAMMA PCB, set 2)
+// SNK vs. Capcom - SVC Chaos (JAMMA PCB, NEO-MVH MVOB PCB)
 
 static struct BurnRomInfo svcpcbaRomDesc[] = {
 	/* alt PCB version, this one has the same program roms as the MVS set, and different GFX / Sound rom arrangements */
@@ -9321,9 +9321,9 @@ static struct BurnRomInfo svcpcbaRomDesc[] = {
 STDROMPICKEXT(svcpcba, svcpcba, svcpcbBIOS)
 STD_ROM_FN(svcpcba)
 
-struct BurnDriver BurnDrvsvcpcba = {
+struct BurnDriver BurnDrvSvcpcba = {
 	"svcpcba", "svcpcb", NULL, NULL, "2003",
-	"SNK vs. Capcom - SVC Chaos (JAMMA PCB, set 2)\0", NULL, "SNK Playmore", "Neo Geo MVS",
+	"SNK vs. Capcom - SVC Chaos (JAMMA PCB, NEO-MVH MVOB PCB)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_SNK_DEDICATED_PCB | HARDWARE_SNK_CMC50 | HARDWARE_SNK_ALTERNATE_TEXT | HARDWARE_SNK_P32 | HARDWARE_SNK_ENCRYPTED_M1, GBF_VSFIGHT, FBF_KOF | FBF_SF,
 	NULL, svcpcbaRomInfo, svcpcbaRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, svcpcbDIPInfo,
@@ -9360,7 +9360,7 @@ static struct BurnRomInfo svcRomDesc[] = {
 STDROMPICKEXT(svc, svc, neogeo)
 STD_ROM_FN(svc)
 
-struct BurnDriver BurnDrvsvc = {
+struct BurnDriver BurnDrvSvc = {
 	"svc", NULL, "neogeo", NULL, "2003",
 	"SNK vs. Capcom - SVC Chaos (NGM-2690)(NGH-2690)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9453,7 +9453,7 @@ static INT32 svcbootInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsvcboot = {
+struct BurnDriver BurnDrvSvcboot = {
 	"svcboot", "svc", "neogeo", NULL, "2003",
 	"SNK vs. Capcom - SVC Chaos (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9539,7 +9539,7 @@ static INT32 svcplusInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsvcplus = {
+struct BurnDriver BurnDrvSvcplus = {
 	"svcplus", "svc", "neogeo", NULL, "2003",
 	"SNK vs. Capcom - SVC Chaos Plus (bootleg set 1)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9610,7 +9610,7 @@ static INT32 svcplusaInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsvcplusa = {
+struct BurnDriver BurnDrvSvcplusa = {
 	"svcplusa", "svc", "neogeo", NULL, "2003",
 	"SNK vs. Capcom - SVC Chaos Plus (bootleg set 2)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9695,7 +9695,7 @@ static INT32 svcsplusInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsvcsplus = {
+struct BurnDriver BurnDrvSvcsplus = {
 	"svcsplus", "svc", "neogeo", NULL, "2003",
 	"SNK vs. Capcom - SVC Chaos Super Plus (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -9758,7 +9758,7 @@ static INT32 samsho5Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsamsho5 = {
+struct BurnDriver BurnDrvSamsho5 = {
 	"samsho5", NULL, "neogeo", NULL, "2003",
 	"Samurai Shodown V / Samurai Spirits Zero (NGM-2700, set 1)\0", NULL, "Yuki Enterprise / SNK Playmore", "Neo Geo MVS",
 	L"Samurai Shodown V\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 (NGM-2700, set 1)\0", NULL, NULL, NULL,
@@ -9801,7 +9801,7 @@ static struct BurnRomInfo samsho5aRomDesc[] = {
 STDROMPICKEXT(samsho5a, samsho5a, neogeo)
 STD_ROM_FN(samsho5a)
 
-struct BurnDriver BurnDrvsamsho5a = {
+struct BurnDriver BurnDrvSamsho5a = {
 	"samsho5a", "samsho5", "neogeo", NULL, "2003",
 	"Samurai Shodown V / Samurai Spirits Zero (NGM-2700, set 2)\0", NULL, "Yuki Enterprise / SNK Playmore", "Neo Geo MVS",
 	L"Samurai Shodown V\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 (NGM-2700, set 2)\0", NULL, NULL, NULL,
@@ -9840,7 +9840,7 @@ static struct BurnRomInfo samsho5hRomDesc[] = {
 STDROMPICKEXT(samsho5h, samsho5h, neogeo)
 STD_ROM_FN(samsho5h)
 
-struct BurnDriver BurnDrvsamsho5h = {
+struct BurnDriver BurnDrvSamsho5h = {
 	"samsho5h", "samsho5", "neogeo", NULL, "2003",
 	"Samurai Shodown V / Samurai Spirits Zero (NGH-2700)\0", NULL, "Yuki Enterprise / SNK Playmore", "Neo Geo MVS",
 	L"Samurai Shodown V\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 (NGH-2700)\0", NULL, NULL, NULL,
@@ -9942,7 +9942,7 @@ static INT32 samsho5bInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsamsho5b = {
+struct BurnDriver BurnDrvSamsho5b = {
 	"samsho5b", "samsho5", "neogeo", NULL, "2003",
 	"Samurai Shodown V / Samurai Spirits Zero (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	L"Samurai Shodown V\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 (bootleg)\0", NULL, NULL, NULL,
@@ -10078,7 +10078,7 @@ static INT32 kf2k3pcbInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkf2k3pcb = {
+struct BurnDriver BurnDrvKf2k3pcb = {
 	"kf2k3pcb", NULL, NULL, NULL, "2003",
 	"The King of Fighters 2003 (Japan, JAMMA PCB)\0", NULL, "Playmore / Capcom", "dedicated Neo Geo PCB",
 	NULL, NULL, NULL, NULL,
@@ -10177,7 +10177,7 @@ static INT32 kof2003Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof2003 = {
+struct BurnDriver BurnDrvKof2003 = {
 	"kof2003", NULL, "neogeo", NULL, "2003",
 	"The King of Fighters 2003 (NGM-2710)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10277,7 +10277,7 @@ static INT32 kof2003hInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof2003h = {
+struct BurnDriver BurnDrvKof2003h = {
 	"kof2003h", "kof2003", "neogeo", NULL, "2003",
 	"The King of Fighters 2003 (NGH-2710)\0", NULL, "SNK Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10359,7 +10359,7 @@ static INT32 kf2k3blInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkf2k3bl = {
+struct BurnDriver BurnDrvKf2k3bl = {
 	"kf2k3bl", "kof2003", "neogeo", NULL, "2003",
 	"The King of Fighters 2003 (bootleg set 1)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10467,7 +10467,7 @@ static INT32 kf2k3blaInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkf2k3bla = {
+struct BurnDriver BurnDrvKf2k3bla = {
 	"kf2k3bla", "kof2003", "neogeo", NULL, "2003",
 	"The King of Fighters 2003 (bootleg set 2)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10504,7 +10504,7 @@ static struct BurnRomInfo kf2k3plRomDesc[] = {
 STDROMPICKEXT(kf2k3pl, kf2k3pl, neogeo)
 STD_ROM_FN(kf2k3pl)
 
-struct BurnDriver BurnDrvkf2k3pl = {
+struct BurnDriver BurnDrvKf2k3pl = {
 	"kf2k3pl", "kof2003", "neogeo", NULL, "2003",
 	"The King of Fighters 2004 Plus / Hero (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10574,7 +10574,7 @@ static INT32 kof2k3uplInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkf2k3upl = {
+struct BurnDriver BurnDrvKf2k3upl = {
 	"kf2k3upl", "kof2003", "neogeo", NULL, "2003",
 	"The King of Fighters 2004 Ultra Plus (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10640,7 +10640,7 @@ static INT32 samsh5spInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvsamsh5sp = {
+struct BurnDriver BurnDrvSamsh5sp = {
 	"samsh5sp", NULL, "neogeo", NULL, "2004",
 	"Samurai Shodown V Special / Samurai Spirits Zero Special (NGM-2720)\0", NULL, "Yuki Enterprise / SNK Playmore", "Neo Geo MVS",
 	L"Samurai Shodown V Special\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 Special  (NGM-2720)\0", NULL, NULL, NULL,
@@ -10691,7 +10691,7 @@ static struct BurnRomInfo samsh5sphRomDesc[] = {
 STDROMPICKEXT(samsh5sph, samsh5sph, neogeo)
 STD_ROM_FN(samsh5sph)
 
-struct BurnDriver BurnDrvsamsh5sph = {
+struct BurnDriver BurnDrvSamsh5sph = {
 	"samsh5sph", "samsh5sp", "neogeo", NULL, "2004",
 	"Samurai Shodown V Special / Samurai Spirits Zero Special (NGH-2720) (2nd release, less censored)\0", NULL, "Yuki Enterprise / SNK Playmore", "Neo Geo MVS",
 	L"Samurai Shodown V Special\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 Special (NGH-2720) (2nd release, less censored)\0", NULL, NULL, NULL,
@@ -10731,7 +10731,7 @@ static struct BurnRomInfo samsh5sphoRomDesc[] = {
 STDROMPICKEXT(samsh5spho, samsh5spho, neogeo)
 STD_ROM_FN(samsh5spho)
 
-struct BurnDriver BurnDrvsamsh5spho = {
+struct BurnDriver BurnDrvSamsh5spho = {
 	"samsh5spho", "samsh5sp", "neogeo", NULL, "2004",
 	"Samurai Shodown V Special / Samurai Spirits Zero Special (NGH-2720) (1st release, censored)\0", NULL, "Yuki Enterprise / SNK Playmore", "Neo Geo MVS",
 	L"Samurai Shodown V Special\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 Special (NGH-2720) (1st release, censored)\0", NULL, NULL, NULL,
@@ -10766,7 +10766,7 @@ static struct BurnRomInfo maglordRomDesc[] = {
 STDROMPICKEXT(maglord, maglord, neogeo)
 STD_ROM_FN(maglord)
 
-struct BurnDriver BurnDrvmaglord = {
+struct BurnDriver BurnDrvMaglord = {
 	"maglord", NULL, "neogeo", NULL, "1990",
 	"Magician Lord (NGM-005)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10801,7 +10801,7 @@ static struct BurnRomInfo maglordhRomDesc[] = {
 STDROMPICKEXT(maglordh, maglordh, neogeo)
 STD_ROM_FN(maglordh)
 
-struct BurnDriver BurnDrvmaglordh = {
+struct BurnDriver BurnDrvMaglordh = {
 	"maglordh", "maglord", "neogeo", NULL, "1990",
 	"Magician Lord (NGH-005)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10837,7 +10837,7 @@ static struct BurnRomInfo ncombatRomDesc[] = {
 STDROMPICKEXT(ncombat, ncombat, neogeo)
 STD_ROM_FN(ncombat)
 
-struct BurnDriver BurnDrvncombat = {
+struct BurnDriver BurnDrvNcombat = {
 	"ncombat", NULL, "neogeo", NULL, "1990",
 	"Ninja Combat (NGM-009)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10874,7 +10874,7 @@ static struct BurnRomInfo ncombathRomDesc[] = {
 STDROMPICKEXT(ncombath, ncombath, neogeo)
 STD_ROM_FN(ncombath)
 
-struct BurnDriver BurnDrvncombath = {
+struct BurnDriver BurnDrvNcombath = {
 	"ncombath", "ncombat", "neogeo", NULL, "1990",
 	"Ninja Combat (NGH-009)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10906,7 +10906,7 @@ static struct BurnRomInfo bjourneyRomDesc[] = {
 STDROMPICKEXT(bjourney, bjourney, neogeo)
 STD_ROM_FN(bjourney)
 
-struct BurnDriver BurnDrvbjourney = {
+struct BurnDriver BurnDrvBjourney = {
 	"bjourney", NULL, "neogeo", NULL, "1990",
 	"Blue's Journey / Raguy (ALM-001)(ALH-001)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10938,7 +10938,7 @@ static struct BurnRomInfo bjourneyhRomDesc[] = {
 STDROMPICKEXT(bjourneyh, bjourneyh, neogeo)
 STD_ROM_FN(bjourneyh)
 
-struct BurnDriver BurnDrvbjourneyh = {
+struct BurnDriver BurnDrvBjourneyh = {
 	"bjourneyh", "bjourney", "neogeo", NULL, "1990",
 	"Blue's Journey / Raguy (ALH-001)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -10969,7 +10969,7 @@ static struct BurnRomInfo crswordRomDesc[] = {
 STDROMPICKEXT(crsword, crsword, neogeo)
 STD_ROM_FN(crsword)
 
-struct BurnDriver BurnDrvcrsword = {
+struct BurnDriver BurnDrvCrsword = {
 	"crsword", NULL, "neogeo", NULL, "1991",
 	"Crossed Swords (ALM-002)(ALH-002)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11004,7 +11004,7 @@ static struct BurnRomInfo trallyRomDesc[] = {
 STDROMPICKEXT(trally, trally, neogeo)
 STD_ROM_FN(trally)
 
-struct BurnDriver BurnDrvtrally = {
+struct BurnDriver BurnDrvTrally = {
 	"trally", NULL, "neogeo", NULL, "1991",
 	"Thrash Rally (ALM-003)(ALH-003)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11035,7 +11035,7 @@ static struct BurnRomInfo ncommandRomDesc[] = {
 STDROMPICKEXT(ncommand, ncommand, neogeo)
 STD_ROM_FN(ncommand)
 
-struct BurnDriver BurnDrvncommand = {
+struct BurnDriver BurnDrvNcommand = {
 	"ncommand", NULL, "neogeo", NULL, "1992",
 	"Ninja Commando\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11071,7 +11071,7 @@ static struct BurnRomInfo wh1RomDesc[] = {
 STDROMPICKEXT(wh1, wh1, neogeo)
 STD_ROM_FN(wh1)
 
-struct BurnDriver BurnDrvwh1 = {
+struct BurnDriver BurnDrvWh1 = {
 	"wh1", NULL, "neogeo", NULL, "1992",
 	"World Heroes (ALM-005)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11109,7 +11109,7 @@ static struct BurnRomInfo wh1hRomDesc[] = {
 STDROMPICKEXT(wh1h, wh1h, neogeo)
 STD_ROM_FN(wh1h)
 
-struct BurnDriver BurnDrvwh1h = {
+struct BurnDriver BurnDrvWh1h = {
 	"wh1h", "wh1", "neogeo", NULL, "1992",
 	"World Heroes (ALH-005)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11143,7 +11143,7 @@ static struct BurnRomInfo wh1haRomDesc[] = {
 STDROMPICKEXT(wh1ha, wh1ha, neogeo)
 STD_ROM_FN(wh1ha)
 
-struct BurnDriver BurnDrvwh1ha = {
+struct BurnDriver BurnDrvWh1ha = {
 	"wh1ha", "wh1", "neogeo", NULL, "1992",
 	"World Heroes (set 3)\0", NULL, "Alpha Denshi Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11177,7 +11177,7 @@ static struct BurnRomInfo wh2RomDesc[] = {
 STDROMPICKEXT(wh2, wh2, neogeo)
 STD_ROM_FN(wh2)
 
-struct BurnDriver BurnDrvwh2 = {
+struct BurnDriver BurnDrvWh2 = {
 	"wh2", NULL, "neogeo", NULL, "1993",
 	"World Heroes 2 (ALM-006)(ALH-006)\0", NULL, "ADK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11211,7 +11211,7 @@ static struct BurnRomInfo wh2hRomDesc[] = {
 STDROMPICKEXT(wh2h, wh2h, neogeo)
 STD_ROM_FN(wh2h)
 
-struct BurnDriver BurnDrvwh2h = {
+struct BurnDriver BurnDrvWh2h = {
 	"wh2h", "wh2", "neogeo", NULL, "1993",
 	"World Heroes 2 (ALH-006)\0", NULL, "ADK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11251,7 +11251,7 @@ static struct BurnRomInfo wh2jRomDesc[] = {
 STDROMPICKEXT(wh2j, wh2j, neogeo)
 STD_ROM_FN(wh2j)
 
-struct BurnDriver BurnDrvwh2j = {
+struct BurnDriver BurnDrvWh2j = {
 	"wh2j", NULL, "neogeo", NULL, "1994",
 	"World Heroes 2 Jet (ADM-007)(ADH-007)\0", NULL, "ADK / SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11287,7 +11287,7 @@ static struct BurnRomInfo aodkRomDesc[] = {
 STDROMPICKEXT(aodk, aodk, neogeo)
 STD_ROM_FN(aodk)
 
-struct BurnDriver BurnDrvaodk = {
+struct BurnDriver BurnDrvAodk = {
 	"aodk", NULL, "neogeo", NULL, "1994",
 	"Aggressors of Dark Kombat / Tsuukai GANGAN Koushinkyoku (ADM-008)(ADH-008)\0", NULL, "ADK / SNK", "Neo Geo MVS",
 	L"Aggressors of Dark Kombat\0\u75DB\u5FEB\uFF27\uFF41\uFF4E\uFF47\uFF41\uFF4E\u884C\u9032\u66F2 (ADM-008)(ADH-008)\0", NULL, NULL, NULL,
@@ -11326,7 +11326,7 @@ static struct BurnRomInfo whpRomDesc[] = {
 STDROMPICKEXT(whp, whp, neogeo)
 STD_ROM_FN(whp)
 
-struct BurnDriver BurnDrvwhp = {
+struct BurnDriver BurnDrvWhp = {
 	"whp", NULL, "neogeo", NULL, "1995",
 	"World Heroes Perfect\0", NULL, "ADK / SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11354,7 +11354,7 @@ static struct BurnRomInfo moshougiRomDesc[] = {
 STDROMPICKEXT(moshougi, moshougi, neogeo)
 STD_ROM_FN(moshougi)
 
-struct BurnDriver BurnDrvmoshougi = {
+struct BurnDriver BurnDrvMoshougi = {
 	"moshougi", NULL, "neogeo", NULL, "1995",
 	"Syougi No Tatsujin - Master of Shougi\0", NULL, "ADK / SNK", "Neo Geo MVS",
 	L"\u5C06\u68CB\u306E\u9054\u4EBA\0Master of Shougi\0", NULL, NULL, NULL,
@@ -11386,7 +11386,7 @@ static struct BurnRomInfo overtopRomDesc[] = {
 STDROMPICKEXT(overtop, overtop, neogeo)
 STD_ROM_FN(overtop)
 
-struct BurnDriver BurnDrvovertop = {
+struct BurnDriver BurnDrvOvertop = {
 	"overtop", NULL, "neogeo", NULL, "1996",
 	"Over Top\0", NULL, "ADK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11425,7 +11425,7 @@ static struct BurnRomInfo ninjamasRomDesc[] = {
 STDROMPICKEXT(ninjamas, ninjamas, neogeo)
 STD_ROM_FN(ninjamas)
 
-struct BurnDriver BurnDrvninjamas = {
+struct BurnDriver BurnDrvNinjamas = {
 	"ninjamas", NULL, "neogeo", NULL, "1996",
 	"Ninja Master's - haoh-ninpo-cho\0", NULL, "ADK / SNK", "Neo Geo MVS",
 	L"Ninja master's \u8987\u738B\u5FCD\u6CD5\u5E16\0Ninja Master's haoh ninpo cho\0", NULL, NULL, NULL,
@@ -11456,7 +11456,7 @@ static struct BurnRomInfo twinspriRomDesc[] = {
 STDROMPICKEXT(twinspri, twinspri, neogeo)
 STD_ROM_FN(twinspri)
 
-struct BurnDriver BurnDrvtwinspri = {
+struct BurnDriver BurnDrvTwinspri = {
 	"twinspri", NULL, "neogeo", NULL, "1996",
 	"Twinkle Star Sprites\0", NULL, "ADK", "Neo Geo MVS",
 	L"TwinkleStar Sprites\0\u30C6\u30A3\u30F3\u30AF\u30EB\u30B9\u30BF\u30FC\u30B9\u30D7\u30E9\u30A4\u30C4\0", NULL, NULL, NULL,
@@ -11484,7 +11484,7 @@ static struct BurnRomInfo zintrckbRomDesc[] = {
 STDROMPICKEXT(zintrckb, zintrckb, neogeo)
 STD_ROM_FN(zintrckb)
 
-struct BurnDriver BurnDrvzintrckb = {
+struct BurnDriver BurnDrvZintrckb = {
 	"zintrckb", NULL, "neogeo", NULL, "1996",
 	"Zintrick / Oshidashi Zentrix (hack / bootleg)\0", NULL, "hack / bootleg", "Neo Geo MVS",
 	L"Zintrick\0\u62BC\u3057\u51FA\u3057\u30B8\u30F3\u30C8\u30EA\u30C3\u30AF (hack / bootleg)\0", NULL, NULL, NULL,
@@ -11514,7 +11514,7 @@ static struct BurnRomInfo viewpoinRomDesc[] = {
 STDROMPICKEXT(viewpoin, viewpoin, neogeo)
 STD_ROM_FN(viewpoin)
 
-struct BurnDriver BurnDrvviewpoin = {
+struct BurnDriver BurnDrvViewpoin = {
 	"viewpoin", NULL, "neogeo", NULL, "1992",
 	"Viewpoint\0", NULL, "Sammy / Aicom", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11596,7 +11596,7 @@ static struct BurnRomInfo janshinRomDesc[] = {
 STDROMPICKEXT(janshin, janshin, neogeo)
 STD_ROM_FN(janshin)
 
-struct BurnDriver BurnDrvjanshin = {
+struct BurnDriver BurnDrvJanshin = {
 	"janshin", NULL, "neogeo", NULL, "1994",
 	"Jyanshin Densetsu - Quest of Jongmaster\0", NULL, "Aicom", "Neo Geo MVS",
 	L"\u96C0\u795E\u4F1D\u8AAC - quest of jongmaster\0Jyanshin Densetsu\0", NULL, NULL, NULL,
@@ -11632,7 +11632,7 @@ static struct BurnRomInfo pulstarRomDesc[] = {
 STDROMPICKEXT(pulstar, pulstar, neogeo)
 STD_ROM_FN(pulstar)
 
-struct BurnDriver BurnDrvpulstar = {
+struct BurnDriver BurnDrvPulstar = {
 	"pulstar", NULL, "neogeo", NULL, "1995",
 	"Pulstar\0", NULL, "Aicom", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11668,7 +11668,7 @@ static struct BurnRomInfo blazstarRomDesc[] = {
 STDROMPICKEXT(blazstar, blazstar, neogeo)
 STD_ROM_FN(blazstar)
 
-struct BurnDriver BurnDrvblazstar = {
+struct BurnDriver BurnDrvBlazstar = {
 	"blazstar", NULL, "neogeo", NULL, "1998",
 	"Blazing Star\0", NULL, "Yumekobo", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11709,7 +11709,7 @@ INT32 preisle2Init()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvpreisle2 = {
+struct BurnDriver BurnDrvPreisle2 = {
 	"preisle2", NULL, "neogeo", NULL, "1999",
 	"Prehistoric Isle 2\0", NULL, "Yumekobo", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11744,7 +11744,7 @@ static struct BurnRomInfo spinmastRomDesc[] = {
 STDROMPICKEXT(spinmast, spinmast, neogeo)
 STD_ROM_FN(spinmast)
 
-struct BurnDriver BurnDrvspinmast = {
+struct BurnDriver BurnDrvSpinmast = {
 	"spinmast", NULL, "neogeo", NULL, "1993",
 	"Spin Master / Miracle Adventure\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11780,7 +11780,7 @@ static struct BurnRomInfo wjammersRomDesc[] = {
 STDROMPICKEXT(wjammers, wjammers, neogeo)
 STD_ROM_FN(wjammers)
 
-struct BurnDriver BurnDrvwjammers = {
+struct BurnDriver BurnDrvWjammers = {
 	"wjammers", NULL, "neogeo", NULL, "1994",
 	"Windjammers / Flying Power Disc\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11812,7 +11812,7 @@ static struct BurnRomInfo karnovrRomDesc[] = {
 STDROMPICKEXT(karnovr, karnovr, neogeo)
 STD_ROM_FN(karnovr)
 
-struct BurnDriver BurnDrvkarnovr = {
+struct BurnDriver BurnDrvKarnovr = {
 	"karnovr", NULL, "neogeo", NULL, "1994",
 	"Karnov's Revenge / Fighter's History Dynamite\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11845,7 +11845,7 @@ static struct BurnRomInfo karnovreRomDesc[] = {
 STDROMPICKEXT(karnovre, karnovre, neogeo)
 STD_ROM_FN(karnovre)
 
-struct BurnDriver BurnDrvkarnovre = {
+struct BurnDriver BurnDrvKarnovre = {
 	"karnovre", "karnovr", "neogeo", NULL, "2024",
 	"Karnov's Revenge / Fighter's History Dynamite (Revolution v0.2, Hack)\0", NULL, "GameHackFan", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11879,7 +11879,7 @@ static struct BurnRomInfo strhoopRomDesc[] = {
 STDROMPICKEXT(strhoop, strhoop, neogeo)
 STD_ROM_FN(strhoop)
 
-struct BurnDriver BurnDrvstrhoop = {
+struct BurnDriver BurnDrvStrhoop = {
 	"strhoop", NULL, "neogeo", NULL, "1994",
 	"Street Hoop / Street Slam / Dunk Dream (DEM-004) (DEH-004)\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -11907,7 +11907,7 @@ static struct BurnRomInfo ghostlopRomDesc[] = {
 STDROMPICKEXT(ghostlop, ghostlop, neogeo)
 STD_ROM_FN(ghostlop)
 
-struct BurnDriver BurnDrvghostlop = {
+struct BurnDriver BurnDrvGhostlop = {
 	"ghostlop", NULL, "neogeo", NULL, "1996",
 	"Ghostlop (prototype)\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	L"Ghostlop \u30B4\u30FC\u30B9\u30C8\u30ED\u30C3\u30D7 (prototype)\0", NULL, NULL, NULL,
@@ -11935,7 +11935,7 @@ static struct BurnRomInfo magdrop2RomDesc[] = {
 STDROMPICKEXT(magdrop2, magdrop2, neogeo)
 STD_ROM_FN(magdrop2)
 
-struct BurnDriver BurnDrvmagdrop2 = {
+struct BurnDriver BurnDrvMagdrop2 = {
 	"magdrop2", NULL, "neogeo", NULL, "1996",
 	"Magical Drop II\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	L"Magical Drop II\0\u30DE\u30B8\u30AB\u30EB\u30C9\u30ED\u30C3\u30D7\uFF12\0", NULL, NULL, NULL,
@@ -11966,7 +11966,7 @@ static struct BurnRomInfo magdrop3RomDesc[] = {
 STDROMPICKEXT(magdrop3, magdrop3, neogeo)
 STD_ROM_FN(magdrop3)
 
-struct BurnDriver BurnDrvmagdrop3 = {
+struct BurnDriver BurnDrvMagdrop3 = {
 	"magdrop3", NULL, "neogeo", NULL, "1997",
 	"Magical Drop III\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	L"Magical Drop III\0\u30DE\u30B8\u30AB\u30EB\u30C9\u30ED\u30C3\u30D7III\0", NULL, NULL, NULL,
@@ -12005,7 +12005,7 @@ static struct BurnRomInfo magdrop3teRomDesc[] = {
 STDROMPICKEXT(magdrop3te, magdrop3te, neogeo)
 STD_ROM_FN(magdrop3te)
 
-struct BurnDriver BurnDrvmagdrop3te = {
+struct BurnDriver BurnDrvMagdrop3te = {
 	"magdrop3te", "magdrop3", "neogeo", NULL, "2022",
 	"Magical Drop III Tournament Edition\0", NULL, "hack", "Neo Geo MVS",
 	L"Magical Drop III\0\u30DE\u30B8\u30AB\u30EB\u30C9\u30ED\u30C3\u30D7III Tournament Edition\0", NULL, NULL, NULL,
@@ -12040,7 +12040,7 @@ INT32 nitdInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvnitd = {
+struct BurnDriver BurnDrvNitd = {
 	"nitd", NULL, "neogeo", NULL, "2000",
 	"Nightmare in the Dark\0", NULL, "Eleven / Gavaking", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12072,7 +12072,7 @@ static struct BurnRomInfo nitdblRomDesc[] = {
 STDROMPICKEXT(nitdbl, nitdbl, neogeo)
 STD_ROM_FN(nitdbl)
 
-struct BurnDriver BurnDrvnitdbl = {
+struct BurnDriver BurnDrvNitdbl = {
 	"nitdbl", "nitd", "neogeo", NULL, "2001",
 	"Nightmare in the Dark (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12102,7 +12102,7 @@ static struct BurnRomInfo gururinRomDesc[] = {
 STDROMPICKEXT(gururin, gururin, neogeo)
 STD_ROM_FN(gururin)
 
-struct BurnDriver BurnDrvgururin = {
+struct BurnDriver BurnDrvGururin = {
 	"gururin", NULL, "neogeo", NULL, "1994",
 	"Gururin\0", NULL, "Face", "Neo Geo MVS",
 	L"\u3050\u308B\u308A\u3093\0Gururin\0", NULL, NULL, NULL,
@@ -12133,7 +12133,7 @@ static struct BurnRomInfo miexchngRomDesc[] = {
 STDROMPICKEXT(miexchng, miexchng, neogeo)
 STD_ROM_FN(miexchng)
 
-struct BurnDriver BurnDrvmiexchng = {
+struct BurnDriver BurnDrvMiexchng = {
 	"miexchng", NULL, "neogeo", NULL, "1997",
 	"Money Puzzle Exchanger / Money Idol Exchanger\0", NULL, "Face", "Neo Geo MVS",
 	L"Money Puzzle Exchanger\0\u30DE\u30CD\u30FC\u30A2\u30A4\u30C9\u30EB\u30A8\u30AF\u30B9\u30C1\u30A7\u30F3\u30B8\u30E3\u30FC\0", NULL, NULL, NULL,
@@ -12163,7 +12163,7 @@ static struct BurnRomInfo panicbomRomDesc[] = {
 STDROMPICKEXT(panicbom, panicbom, neogeo)
 STD_ROM_FN(panicbom)
 
-struct BurnDriver BurnDrvpanicbom = {
+struct BurnDriver BurnDrvPanicbom = {
 	"panicbom", NULL, "neogeo", NULL, "1994",
 	"Panic Bomber\0", NULL, "Eighting / Hudson", "Neo Geo MVS",
 	L"Panic Bomber\0\u3071\u306B\u3063\u304F\u30DC\u30F3\u30D0\u30FC \u30DC\u30F3\u30D0\u30FC\u30DE\u30F3\0", NULL, NULL, NULL,
@@ -12197,7 +12197,7 @@ static struct BurnRomInfo kabukiklRomDesc[] = {
 STDROMPICKEXT(kabukikl, kabukikl, neogeo)
 STD_ROM_FN(kabukikl)
 
-struct BurnDriver BurnDrvkabukikl = {
+struct BurnDriver BurnDrvKabukikl = {
 	"kabukikl", NULL, "neogeo", NULL, "1995",
 	"Far East of Eden - Kabuki Klash / Tengai Makyou - Shin Den\0", NULL, "Hudson", "Neo Geo MVS",
 	L"Kabuki Klash - far east of eden\0\u5929\u5916\u9B54\u5883 - \u771F\u4F1D\0", NULL, NULL, NULL,
@@ -12230,7 +12230,7 @@ static struct BurnRomInfo kabukiklbRomDesc[] = {
 STDROMPICKEXT(kabukiklb, kabukiklb, neogeo)
 STD_ROM_FN(kabukiklb)
 
-struct BurnDriver BurnDrvkabukiklb = {
+struct BurnDriver BurnDrvKabukiklb = {
 	"kabukiklb", "kabukikl", "neogeo", NULL, "1995",
 	"Far East of Eden - Kabuki Klash / Tengai Makyou - Shin Den (Add hidden characters)\0", NULL, "Ydmis / Creamymami[EGCG]", "Neo Geo MVS",
 	L"Kabuki Klash - far east of eden\0\u5929\u5916\u9B54\u5883 - \u771F\u4F1D (Add hidden characters)\0", NULL, NULL, NULL,
@@ -12262,7 +12262,7 @@ static struct BurnRomInfo neobombeRomDesc[] = {
 STDROMPICKEXT(neobombe, neobombe, neogeo)
 STD_ROM_FN(neobombe)
 
-struct BurnDriver BurnDrvneobombe = {
+struct BurnDriver BurnDrvNeobombe = {
 	"neobombe", NULL, "neogeo", NULL, "1997",
 	"Neo Bomberman\0", NULL, "Hudson", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12294,7 +12294,7 @@ static struct BurnRomInfo minasanRomDesc[] = {
 STDROMPICKEXT(minasan, minasan, neogeo)
 STD_ROM_FN(minasan)
 
-struct BurnDriver BurnDrvminasan = {
+struct BurnDriver BurnDrvMinasan = {
 	"minasan", NULL, "neogeo", NULL, "1990",
 	"Minasanno Okagesamadesu! Daisugorokutaikai (MOM-001)(MOH-001)\0", NULL, "Monolith Corp.", "Neo Geo MVS",
 	L"\u307F\u306A\u3055\u3093\u306E\u304A\u304B\u3052\u3055\u307E\u3067\u3059\uFF01\0Minnasanno Okagesamadesu (MOM-001)(MOH-001)\0", NULL, NULL, NULL,
@@ -12326,7 +12326,7 @@ static struct BurnRomInfo bakatonoRomDesc[] = {
 STDROMPICKEXT(bakatono, bakatono, neogeo)
 STD_ROM_FN(bakatono)
 
-struct BurnDriver BurnDrvbakatono = {
+struct BurnDriver BurnDrvBakatono = {
 	"bakatono", NULL, "neogeo", NULL, "1991",
 	"Bakatonosama Mahjong Manyuuki (MOM-002)(MOH-002)\0", NULL, "Monolith Corp.", "Neo Geo MVS",
 	L"\u30D0\u30AB\u6BBF\u69D8 \u9EBB\u96C0\u6F2B\u904A\u8A18\0Bakatonosama Mahjong Manyuki (MOM-002)(MOH-002)\0", NULL, NULL, NULL,
@@ -12357,7 +12357,7 @@ static struct BurnRomInfo turfmastRomDesc[] = {
 STDROMPICKEXT(turfmast, turfmast, neogeo)
 STD_ROM_FN(turfmast)
 
-struct BurnDriver BurnDrvturfmast = {
+struct BurnDriver BurnDrvTurfmast = {
 	"turfmast", NULL, "neogeo", NULL, "1996",
 	"Neo Turf Masters / Big Tournament Golf\0", NULL, "Nazca", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12388,7 +12388,7 @@ static struct BurnRomInfo mslugRomDesc[] = {
 STDROMPICKEXT(mslug, mslug, neogeo)
 STD_ROM_FN(mslug)
 
-struct BurnDriver BurnDrvmslug = {
+struct BurnDriver BurnDrvMslug = {
 	"mslug", NULL, "neogeo", NULL, "1996",
 	"Metal Slug - Super Vehicle-001\0", NULL, "Nazca", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12421,7 +12421,7 @@ static struct BurnRomInfo zedbladeRomDesc[] = {
 STDROMPICKEXT(zedblade, zedblade, neogeo)
 STD_ROM_FN(zedblade)
 
-struct BurnDriver BurnDrvzedblade = {
+struct BurnDriver BurnDrvZedblade = {
 	"zedblade", NULL, "neogeo", NULL, "1994",
 	"Zed Blade / Operation Ragnarok\0", NULL, "NMK", "Neo Geo MVS",
 	L"Zed Blade\0Operation Ragnarok\0\u4F5C\u6226\u540D\uFF02\u30E9\u30B0\u30CA\u30ED\u30AF\uFF02\0", NULL, NULL, NULL,
@@ -12467,7 +12467,7 @@ static INT32 s1945pInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvs1945p = {
+struct BurnDriver BurnDrvS1945p = {
 	"s1945p", NULL, "neogeo", NULL, "1999",
 	"Strikers 1945 Plus\0", NULL, "Psikyo", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12500,7 +12500,7 @@ static struct BurnRomInfo quizkofRomDesc[] = {
 STDROMPICKEXT(quizkof, quizkof, neogeo)
 STD_ROM_FN(quizkof)
 
-struct BurnDriver BurnDrvquizkof = {
+struct BurnDriver BurnDrvQuizkof = {
 	"quizkof", NULL, "neogeo", NULL, "1995",
 	"Quiz King of Fighters (SAM-080)(SAH-080)\0", NULL, "Saurus", "Neo Geo MVS",
 	L"\u30AF\u30A4\u30BA\u30AD\u30F3\u30B0\u30AA\u30D6\u30D5\u30A1\u30A4\u30BF\u30FC\u30BA\0Quiz King of Fighters (SAM-080)(SAH-080)\0", NULL, NULL, NULL,
@@ -12536,7 +12536,7 @@ static struct BurnRomInfo quizkofkRomDesc[] = {
 STDROMPICKEXT(quizkofk, quizkofk, neogeo)
 STD_ROM_FN(quizkofk)
 
-struct BurnDriver BurnDrvquizkofk = {
+struct BurnDriver BurnDrvQuizkofk = {
 	"quizkofk", "quizkof", "neogeo", NULL, "1995",
 	"Quiz King of Fighters (Korean release)\0", NULL, "Saurus", "Neo Geo MVS",
 	L"\u30AF\u30A4\u30BA\u30AD\u30F3\u30B0\u30AA\u30D6\u30D5\u30A1\u30A4\u30BF\u30FC\u30BA\0Quiz King of Fighters (Korean release)\0", NULL, NULL, NULL,
@@ -12566,7 +12566,7 @@ static struct BurnRomInfo stakwinRomDesc[] = {
 STDROMPICKEXT(stakwin, stakwin, neogeo)
 STD_ROM_FN(stakwin)
 
-struct BurnDriver BurnDrvstakwin = {
+struct BurnDriver BurnDrvStakwin = {
 	"stakwin", NULL, "neogeo", NULL, "1995",
 	"Stakes Winner / Stakes Winner - GI kinzen seiha e no michi\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12601,10 +12601,10 @@ static struct BurnRomInfo ragnagrdRomDesc[] = {
 STDROMPICKEXT(ragnagrd, ragnagrd, neogeo)
 STD_ROM_FN(ragnagrd)
 
-struct BurnDriver BurnDrvragnagrd = {
+struct BurnDriver BurnDrvRagnagrd = {
 	"ragnagrd", NULL, "neogeo", NULL, "1996",
 	"Ragnagard / Shin-Oh-Ken\0", NULL, "Saurus", "Neo Geo MVS",
-	L"Operation Ragnagard\0\u795E\u51F0\u62F3\0", NULL, NULL, NULL,
+	L"Ragnagard\0\u795E\u51F0\u62F3\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, 0,
 	NULL, ragnagrdRomInfo, ragnagrdRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
@@ -12632,7 +12632,7 @@ static struct BurnRomInfo pgoalRomDesc[] = {
 STDROMPICKEXT(pgoal, pgoal, neogeo)
 STD_ROM_FN(pgoal)
 
-struct BurnDriver BurnDrvpgoal = {
+struct BurnDriver BurnDrvPgoal = {
 	"pgoal", NULL, "neogeo", NULL, "1996",
 	"Pleasure Goal / Futsal - 5 on 5 Mini Soccer (NGM-219)\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12663,7 +12663,7 @@ static struct BurnRomInfo ironcladRomDesc[] = {
 STDROMPICKEXT(ironclad, ironclad, neogeo)
 STD_ROM_FN(ironclad)
 
-struct BurnDriver BurnDrvironclad = {
+struct BurnDriver BurnDrvIronclad = {
 	"ironclad", NULL, "neogeo", NULL, "1996",
 	"Choutetsu Brikin'ger - Iron clad (Prototype)\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12694,7 +12694,7 @@ static struct BurnRomInfo ironcladoRomDesc[] = {
 STDROMPICKEXT(ironclado, ironclado, neogeo)
 STD_ROM_FN(ironclado)
 
-struct BurnDriver BurnDrvironclado = {
+struct BurnDriver BurnDrvIronclado = {
 	"ironclado", "ironclad", "neogeo", NULL, "1996",
 	"Choutetsu Brikin'ger - Iron clad (Prototype, older)\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12725,7 +12725,7 @@ static struct BurnRomInfo stakwin2RomDesc[] = {
 STDROMPICKEXT(stakwin2, stakwin2, neogeo)
 STD_ROM_FN(stakwin2)
 
-struct BurnDriver BurnDrvstakwin2 = {
+struct BurnDriver BurnDrvStakwin2 = {
 	"stakwin2", NULL, "neogeo", NULL, "1996",
 	"Stakes Winner 2\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12762,7 +12762,7 @@ static struct BurnRomInfo shocktroRomDesc[] = {
 STDROMPICKEXT(shocktro, shocktro, neogeo)
 STD_ROM_FN(shocktro)
 
-struct BurnDriver BurnDrvshocktro = {
+struct BurnDriver BurnDrvShocktro = {
 	"shocktro", NULL, "neogeo", NULL, "1997",
 	"Shock Troopers (set 1)\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12800,7 +12800,7 @@ static struct BurnRomInfo shocktroaRomDesc[] = {
 STDROMPICKEXT(shocktroa, shocktroa, neogeo)
 STD_ROM_FN(shocktroa)
 
-struct BurnDriver BurnDrvshocktroa = {
+struct BurnDriver BurnDrvShocktroa = {
 	"shocktroa", "shocktro", "neogeo", NULL, "1997",
 	"Shock Troopers (set 2)\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12835,7 +12835,7 @@ static struct BurnRomInfo shocktr2RomDesc[] = {
 STDROMPICKEXT(shocktr2, shocktr2, neogeo)
 STD_ROM_FN(shocktr2)
 
-struct BurnDriver BurnDrvshocktr2 = {
+struct BurnDriver BurnDrvShocktr2 = {
 	"shocktr2", NULL, "neogeo", NULL, "1998",
 	"Shock Troopers - 2nd Squad\0", NULL, "Saurus", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12928,7 +12928,7 @@ static INT32 lans2004Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvlans2004 = {
+struct BurnDriver BurnDrvLans2004 = {
 	"lans2004", "shocktr2", "neogeo", NULL, "1998",
 	"Lansquenet 2004 (Shock Troopers - 2nd Squad bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12964,7 +12964,7 @@ static struct BurnRomInfo galaxyfgRomDesc[] = {
 STDROMPICKEXT(galaxyfg, galaxyfg, neogeo)
 STD_ROM_FN(galaxyfg)
 
-struct BurnDriver BurnDrvgalaxyfg = {
+struct BurnDriver BurnDrvGalaxyfg = {
 	"galaxyfg", NULL, "neogeo", NULL, "1995",
 	"Galaxy Fight - Universal Warriors\0", NULL, "Sunsoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -12998,7 +12998,7 @@ static struct BurnRomInfo wakuwak7RomDesc[] = {
 STDROMPICKEXT(wakuwak7, wakuwak7, neogeo)
 STD_ROM_FN(wakuwak7)
 
-struct BurnDriver BurnDrvwakuwak7 = {
+struct BurnDriver BurnDrvWakuwak7 = {
 	"wakuwak7", NULL, "neogeo", NULL, "1996",
 	"Waku Waku 7\0", NULL, "Sunsoft", "Neo Geo MVS",
 	L"Waku Waku 7\0\u308F\u304F\u308F\u304F\uFF17\0", NULL, NULL, NULL,
@@ -13036,7 +13036,7 @@ static struct BurnRomInfo pbobblenRomDesc[] = {
 STDROMPICKEXT(pbobblen, pbobblen, neogeo)
 STD_ROM_FN(pbobblen)
 
-struct BurnDriver BurnDrvpbobblen = {
+struct BurnDriver BurnDrvPbobblen = {
 	"pbobblen", NULL, "neogeo", NULL, "1994",
 	"Puzzle Bobble / Bust-A-Move (Neo-Geo) (NGM-083)\0", NULL, "Taito", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13066,7 +13066,7 @@ static struct BurnRomInfo pbobblenbRomDesc[] = {
 STDROMPICKEXT(pbobblenb, pbobblenb, neogeo)
 STD_ROM_FN(pbobblenb)
 
-struct BurnDriver BurnDrvpbobblenb = {
+struct BurnDriver BurnDrvPbobblenb = {
 	"pbobblenb", "pbobblen", "neogeo", NULL, "1994",
 	"Puzzle Bobble / Bust-A-Move (Neo-Geo) (bootleg)\0", NULL, "Taito", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13099,7 +13099,7 @@ static struct BurnRomInfo pbobbl2nRomDesc[] = {
 STDROMPICKEXT(pbobbl2n, pbobbl2n, neogeo)
 STD_ROM_FN(pbobbl2n)
 
-struct BurnDriver BurnDrvpbobbl2n = {
+struct BurnDriver BurnDrvPbobbl2n = {
 	"pbobbl2n", NULL, "neogeo", NULL, "1999",
 	"Puzzle Bobble 2 / Bust-A-Move Again (Neo-Geo)\0", NULL, "Taito (SNK license)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13142,7 +13142,7 @@ INT32 pnyaaInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvpnyaa = {
+struct BurnDriver BurnDrvPnyaa = {
 	"pnyaa", NULL, "neogeo", NULL, "2003",
 	"Pochi and Nyaa (Ver 2.02)\0", NULL, "Aiky / Taito", "Neo Geo MVS",
 	L"Pochi and Nyaa\0\u30DD\u30C1\u30C3\u3068\u306B\u3083\uFF5E (Ver 2.02)\0", NULL, NULL, NULL,
@@ -13171,7 +13171,7 @@ static struct BurnRomInfo pnyaaaRomDesc[] = {
 STDROMPICKEXT(pnyaaa, pnyaaa, neogeo)
 STD_ROM_FN(pnyaaa)
 
-struct BurnDriver BurnDrvpnyaaa = {
+struct BurnDriver BurnDrvPnyaaa = {
 	"pnyaaa", "pnyaa", "neogeo", NULL, "2003",
 	"Pochi and Nyaa (Ver 2.00)\0", NULL, "Aiky / Taito", "Neo Geo MVS",
 	L"Pochi and Nyaa\0\u30DD\u30C1\u30C3\u3068\u306B\u3083\uFF5E (Ver 2.00)\0", NULL, NULL, NULL,
@@ -13202,7 +13202,7 @@ static struct BurnRomInfo marukodqRomDesc[] = {
 STDROMPICKEXT(marukodq, marukodq, neogeo)
 STD_ROM_FN(marukodq)
 
-struct BurnDriver BurnDrvmarukodq = {
+struct BurnDriver BurnDrvMarukodq = {
 	"marukodq", NULL, "neogeo", NULL, "1995",
 	"Chibi Marukochan Deluxe Quiz\0", NULL, "Takara", "Neo Geo MVS",
 	L"\u3061\u3073\u307E\u308B\u5B50\u3061\u3083\u3093 \u307E\u308B\u5B50\u30C7\u30E9\u30C3\u30AF\u30B9\u30AF\u30A4\u30BA\0Chibi Marukochan Deluxe Quiz\0", NULL, NULL, NULL,
@@ -13238,7 +13238,7 @@ static struct BurnRomInfo doubledrRomDesc[] = {
 STDROMPICKEXT(doubledr, doubledr, neogeo)
 STD_ROM_FN(doubledr)
 
-struct BurnDriver BurnDrvdoubledr = {
+struct BurnDriver BurnDrvDoubledr = {
 	"doubledr", NULL, "neogeo", NULL, "1995",
 	"Double Dragon (Neo-Geo)\0", NULL, "Technos", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13274,7 +13274,7 @@ static struct BurnRomInfo gowcaizrRomDesc[] = {
 STDROMPICKEXT(gowcaizr, gowcaizr, neogeo)
 STD_ROM_FN(gowcaizr)
 
-struct BurnDriver BurnDrvgowcaizr = {
+struct BurnDriver BurnDrvGowcaizr = {
 	"gowcaizr", NULL, "neogeo", NULL, "1995",
 	"Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer\0", NULL, "Technos", "Neo Geo MVS",
 	L"Voltage Fighter - Gowcaizer\0\u8D85\u4EBA\u5B66\u5712\u30B4\u30A6\u30AB\u30A4\u30B6\u30FC\0", NULL, NULL, NULL,
@@ -13305,7 +13305,7 @@ static struct BurnRomInfo sdodgebRomDesc[] = {
 STDROMPICKEXT(sdodgeb, sdodgeb, neogeo)
 STD_ROM_FN(sdodgeb)
 
-struct BurnDriver BurnDrvsdodgeb = {
+struct BurnDriver BurnDrvSdodgeb = {
 	"sdodgeb", NULL, "neogeo", NULL, "1996",
 	"Super Dodge Ball / Kunio no Nekketsu Toukyuu Densetsu\0", NULL, "Technos", "Neo Geo MVS",
 	L"Super Dodge Ball\0\u304F\u306B\u304A\u306E\u71B1\u8840\u95D8\u7403\u4F1D\u8AAC\0", NULL, NULL, NULL,
@@ -13348,7 +13348,7 @@ static INT32 DragonshInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvdragonsh = {
+struct BurnDriver BurnDrvDragonsh = {
 	"dragonsh", NULL, "neogeo", NULL, "1996",
 	"Dragon's Heaven (development board)\0", NULL, "Face", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13380,7 +13380,7 @@ static struct BurnRomInfo twsoc96RomDesc[] = {
 STDROMPICKEXT(twsoc96, twsoc96, neogeo)
 STD_ROM_FN(twsoc96)
 
-struct BurnDriver BurnDrvtwsoc96 = {
+struct BurnDriver BurnDrvTwsoc96 = {
 	"twsoc96", NULL, "neogeo", NULL, "1996",
 	"Tecmo World Soccer '96\0", NULL, "Tecmo", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13412,7 +13412,7 @@ static struct BurnRomInfo fightfevRomDesc[] = {
 STDROMPICKEXT(fightfev, fightfev, neogeo)
 STD_ROM_FN(fightfev)
 
-struct BurnDriver BurnDrvfightfev = {
+struct BurnDriver BurnDrvFightfev = {
 	"fightfev", NULL, "neogeo", NULL, "1994",
 	"Fight Fever (set 1)\0", NULL, "Viccom", "Neo Geo MVS",
 	L"Fight Fever\0\uC655\uC911\uC655 (set 1)\0", NULL, NULL, NULL,
@@ -13463,7 +13463,7 @@ static INT32 fightfevaInit()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvfightfeva = {
+struct BurnDriver BurnDrvFightfeva = {
 	"fightfeva", "fightfev", "neogeo", NULL, "1994",
 	"Fight Fever (set 2)\0", NULL, "Viccom", "Neo Geo MVS",
 	L"Fight Fever\0\uC655\uC911\uC655 (set 2)\0", NULL, NULL, NULL,
@@ -13498,7 +13498,7 @@ static struct BurnRomInfo pspikes2RomDesc[] = {
 STDROMPICKEXT(pspikes2, pspikes2, neogeo)
 STD_ROM_FN(pspikes2)
 
-struct BurnDriver BurnDrvpspikes2 = {
+struct BurnDriver BurnDrvPspikes2 = {
 	"pspikes2", NULL, "neogeo", NULL, "1994",
 	"Power Spikes II (NGM-068)\0", NULL, "Video System Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13529,7 +13529,7 @@ static struct BurnRomInfo sonicwi2RomDesc[] = {
 STDROMPICKEXT(sonicwi2, sonicwi2, neogeo)
 STD_ROM_FN(sonicwi2)
 
-struct BurnDriver BurnDrvsonicwi2 = {
+struct BurnDriver BurnDrvSonicwi2 = {
 	"sonicwi2", NULL, "neogeo", NULL, "1994",
 	"Aero Fighters 2 / Sonic Wings 2\0", NULL, "Video System Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13560,7 +13560,7 @@ static struct BurnRomInfo sonicwi3RomDesc[] = {
 STDROMPICKEXT(sonicwi3, sonicwi3, neogeo)
 STD_ROM_FN(sonicwi3)
 
-struct BurnDriver BurnDrvsonicwi3 = {
+struct BurnDriver BurnDrvSonicwi3 = {
 	"sonicwi3", NULL, "neogeo", NULL, "1995",
 	"Aero Fighters 3 / Sonic Wings 3\0", NULL, "Video System Co.", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13589,7 +13589,7 @@ static struct BurnRomInfo popbouncRomDesc[] = {
 STDROMPICKEXT(popbounc, popbounc, neogeo)
 STD_ROM_FN(popbounc)
 
-struct BurnDriver BurnDrvpopbounc = {
+struct BurnDriver BurnDrvPopbounc = {
 	"popbounc", NULL, "neogeo", NULL, "1997",
 	"Pop 'n Bounce / Gapporin\0", NULL, "Video System Co.", "Neo Geo MVS",
 	L"Pop 'n Bounce\0\u30AC\u30C3\u30DD\u30EA\u30F3\0", NULL, NULL, NULL,
@@ -13619,7 +13619,7 @@ static struct BurnRomInfo androdunRomDesc[] = {
 STDROMPICKEXT(androdun, androdun, neogeo)
 STD_ROM_FN(androdun)
 
-struct BurnDriver BurnDrvandrodun = {
+struct BurnDriver BurnDrvAndrodun = {
 	"androdun", NULL, "neogeo", NULL, "1992",
 	"Andro Dunos (NGM-049)(NGH-049)\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13648,7 +13648,7 @@ static struct BurnRomInfo b2bRomDesc[] = {
 STDROMPICKEXT(b2b, b2b, neogeo)
 STD_ROM_FN(b2b)
 
-struct BurnDriver BurnDrvb2b = {
+struct BurnDriver BurnDrvB2b = {
 	"b2b", NULL, "neogeo", NULL, "2000",
 	"Bang Bang Busters (2010 NCI release)\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13678,7 +13678,7 @@ static struct BurnRomInfo puzzledpRomDesc[] = {
 STDROMPICKEXT(puzzledp, puzzledp, neogeo)
 STD_ROM_FN(puzzledp)
 
-struct BurnDriver BurnDrvpuzzledp = {
+struct BurnDriver BurnDrvPuzzledp = {
 	"puzzledp", NULL, "neogeo", NULL, "1995",
 	"Puzzle De Pon!\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13709,7 +13709,7 @@ static struct BurnRomInfo neomrdoRomDesc[] = {
 STDROMPICKEXT(neomrdo, neomrdo, neogeo)
 STD_ROM_FN(neomrdo)
 
-struct BurnDriver BurnDrvneomrdo = {
+struct BurnDriver BurnDrvNeomrdo = {
 	"neomrdo", NULL, "neogeo", NULL, "1996",
 	"Neo Mr. Do!\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13740,7 +13740,7 @@ static struct BurnRomInfo goalx3RomDesc[] = {
 STDROMPICKEXT(goalx3, goalx3, neogeo)
 STD_ROM_FN(goalx3)
 
-struct BurnDriver BurnDrvgoalx3 = {
+struct BurnDriver BurnDrvGoalx3 = {
 	"goalx3", NULL, "neogeo", NULL, "1995",
 	"Goal! Goal! Goal!\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13770,7 +13770,7 @@ static struct BurnRomInfo neodriftRomDesc[] = {
 STDROMPICKEXT(neodrift, neodrift, neogeo)
 STD_ROM_FN(neodrift)
 
-struct BurnDriver BurnDrvneodrift = {
+struct BurnDriver BurnDrvNeodrift = {
 	"neodrift", NULL, "neogeo", NULL, "1996",
 	"Neo Drift Out - New Technology\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13801,7 +13801,7 @@ static struct BurnRomInfo breakersRomDesc[] = {
 STDROMPICKEXT(breakers, breakers, neogeo)
 STD_ROM_FN(breakers)
 
-struct BurnDriver BurnDrvbreakers = {
+struct BurnDriver BurnDrvBreakers = {
 	"breakers", NULL, "neogeo", NULL, "1996",
 	"Breakers\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13831,7 +13831,7 @@ static struct BurnRomInfo puzzldprRomDesc[] = {
 STDROMPICKEXT(puzzldpr, puzzldpr, neogeo)
 STD_ROM_FN(puzzldpr)
 
-struct BurnDriver BurnDrvpuzzldpr = {
+struct BurnDriver BurnDrvPuzzldpr = {
 	"puzzldpr", "puzzledp", "neogeo", NULL, "1997",
 	"Puzzle De Pon! R!\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13866,7 +13866,7 @@ static struct BurnRomInfo breakrevRomDesc[] = {
 STDROMPICKEXT(breakrev, breakrev, neogeo)
 STD_ROM_FN(breakrev)
 
-struct BurnDriver BurnDrvbreakrev = {
+struct BurnDriver BurnDrvBreakrev = {
 	"breakrev", NULL, "neogeo", NULL, "1998",
 	"Breakers Revenge\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13901,7 +13901,7 @@ static struct BurnRomInfo brkrevextRomDesc[] = {
 STDROMPICKEXT(brkrevext, brkrevext, neogeo)
 STD_ROM_FN(brkrevext)
 
-struct BurnDriver BurnDrvbrkrevext = {
+struct BurnDriver BurnDrvBrkrevext = {
 	"brkrevext", "breakrev", "neogeo", NULL, "2018",
 	"Breakers Revenge - Extra Mode (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13930,7 +13930,7 @@ static struct BurnRomInfo flipshotRomDesc[] = {
 STDROMPICKEXT(flipshot, flipshot, neogeo)
 STD_ROM_FN(flipshot)
 
-struct BurnDriver BurnDrvflipshot = {
+struct BurnDriver BurnDrvFlipshot = {
 	"flipshot", NULL, "neogeo", NULL, "1998",
 	"Battle Flip Shot\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13960,7 +13960,7 @@ static struct BurnRomInfo ctomadayRomDesc[] = {
 STDROMPICKEXT(ctomaday, ctomaday, neogeo)
 STD_ROM_FN(ctomaday)
 
-struct BurnDriver BurnDrvctomaday = {
+struct BurnDriver BurnDrvCtomaday = {
 	"ctomaday", NULL, "neogeo", NULL, "1999",
 	"Captain Tomaday\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -13994,7 +13994,7 @@ static INT32 ganryuInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvganryu = {
+struct BurnDriver BurnDrvGanryu = {
 	"ganryu", NULL, "neogeo", NULL, "1999",
 	"Ganryu / Musashi Ganryuki\0", NULL, "Visco", "Neo Geo MVS",
 	L"Ganryu\0\u6B66\u8535\u5DCC\u6D41\u8A18\0", NULL, NULL, NULL,
@@ -14029,7 +14029,7 @@ static INT32 bangbeadInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvbangbead = {
+struct BurnDriver BurnDrvBangbead = {
 	"bangbead", NULL, "neogeo", NULL, "2000",
 	"Bang Bead\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14085,7 +14085,7 @@ static INT32 mslug4Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvmslug4 = {
+struct BurnDriver BurnDrvMslug4 = {
 	"mslug4", NULL, "neogeo", NULL, "2002",
 	"Metal Slug 4 (NGM-2630)\0", NULL, "Mega", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14122,7 +14122,7 @@ static struct BurnRomInfo mslug4cRomDesc[] = {
 STDROMPICKEXT(mslug4c, mslug4c, neogeo)
 STD_ROM_FN(mslug4c)
 
-struct BurnDriver BurnDrvmslug4c = {
+struct BurnDriver BurnDrvMslug4c = {
 	"mslug4c", "mslug4", "neogeo", NULL, "2021",
 	"Metal Slug 4 (Enemy Remix, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14159,7 +14159,7 @@ static struct BurnRomInfo mslug4hRomDesc[] = {
 STDROMPICKEXT(mslug4h, mslug4h, neogeo)
 STD_ROM_FN(mslug4h)
 
-struct BurnDriver BurnDrvmslug4h = {
+struct BurnDriver BurnDrvMslug4h = {
 	"mslug4h", "mslug4", "neogeo", NULL, "2002",
 	"Metal Slug 4 (NGH-2630)\0", NULL, "Mega", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14194,7 +14194,7 @@ static struct BurnRomInfo ms4plusRomDesc[] = {
 STDROMPICKEXT(ms4plus, ms4plus, neogeo)
 STD_ROM_FN(ms4plus)
 
-struct BurnDriver BurnDrvms4plus = {
+struct BurnDriver BurnDrvMs4plus = {
 	"ms4plus", "mslug4", "neogeo", NULL, "2002",
 	"Metal Slug 4 Plus (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14243,7 +14243,7 @@ static INT32 rotdInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvrotd = {
+struct BurnDriver BurnDrvRotd = {
 	"rotd", NULL, "neogeo", NULL, "2002",
 	"Rage of the Dragons (NGM-264?)\0", NULL, "Evoga / Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14278,7 +14278,7 @@ struct BurnDriver BurnDrvrotd = {
 STDROMPICKEXT(rotdh, rotdh, neogeo)
 STD_ROM_FN(rotdh)
 
-struct BurnDriver BurnDrvrotdh = {
+struct BurnDriver BurnDrvRotdh = {
 	"rotdh", "rotd", "neogeo", NULL, "2002",
 	"Rage of the Dragons (NGH-2640)\0", NULL, "Evoga / Playmore", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14337,7 +14337,7 @@ static INT32 matrimInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvmatrim = {
+struct BurnDriver BurnDrvMatrim = {
 	"matrim", NULL, "neogeo", NULL, "2002",
 	"Matrimelee / Shin Gouketsuji Ichizoku Toukon (NGM-2660) (NGH-2660)\0", NULL, "Noise Factory / Atlus", "Neo Geo MVS",
 	L"\u65B0\u8C6A\u8840\u5BFA\u4E00\u65CF - \u95D8\u5A5A\0Matrimelee (NGM-2660) (NGH-2660)\0", NULL, NULL, NULL,
@@ -14415,7 +14415,7 @@ static INT32 matrimblInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvmatrimbl = {
+struct BurnDriver BurnDrvMatrimbl = {
 	"matrimbl", "matrim", "neogeo", NULL, "2002",
 	"Matrimelee / Shin Gouketsuji Ichizoku Toukon (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	L"\u65B0\u8C6A\u8840\u5BFA\u4E00\u65CF - \u95D8\u5A5A\0Matrimelee (bootleg)\0", NULL, NULL, NULL,
@@ -14453,7 +14453,7 @@ INT32 jockeygpInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvjockeygp = {
+struct BurnDriver BurnDrvJockeygp = {
 	"jockeygp", NULL, "neogeo", NULL, "2001",
 	"Jockey Grand Prix (set 1)\0", NULL, "Sun Amusement / BrezzaSoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14485,7 +14485,7 @@ static struct BurnRomInfo jockeygpaRomDesc[] = {
 STDROMPICKEXT(jockeygpa, jockeygpa, neogeo)
 STD_ROM_FN(jockeygpa)
 
-struct BurnDriver BurnDrvjockeygpa = {
+struct BurnDriver BurnDrvJockeygpa = {
 	"jockeygpa", "jockeygp", "neogeo", NULL, "2001",
 	"Jockey Grand Prix (set 2)\0", NULL, "Sun Amusement / BrezzaSoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14520,7 +14520,7 @@ static INT32 vlinerInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvvliner = {
+struct BurnDriver BurnDrvVliner = {
 	"vliner", NULL, "neogeo", NULL, "2001",
 	"V-Liner (v0.7a)\0", NULL, "Dyna / BreezaSoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14548,7 +14548,7 @@ static struct BurnRomInfo vliner7eRomDesc[] = {
 STDROMPICKEXT(vliner7e, vliner7e, neogeo)
 STD_ROM_FN(vliner7e)
 
-struct BurnDriver BurnDrvvliner7e = {
+struct BurnDriver BurnDrvVliner7e = {
 	"vliner7e", "vliner", "neogeo", NULL, "2001",
 	"V-Liner (v0.7e)\0", NULL, "Dyna / BreezaSoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14576,7 +14576,7 @@ static struct BurnRomInfo vliner6eRomDesc[] = {
 STDROMPICKEXT(vliner6e, vliner6e, neogeo)
 STD_ROM_FN(vliner6e)
 
-struct BurnDriver BurnDrvvliner6e = {
+struct BurnDriver BurnDrvVliner6e = {
 	"vliner6e", "vliner", "neogeo", NULL, "2001",
 	"V-Liner (v0.6e)\0", NULL, "Dyna / BreezaSoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14604,7 +14604,7 @@ static struct BurnRomInfo vliner54RomDesc[] = {
 STDROMPICKEXT(vliner54, vliner54, neogeo)
 STD_ROM_FN(vliner54)
 
-struct BurnDriver BurnDrvvliner54 = {
+struct BurnDriver BurnDrvVliner54 = {
 	"vliner54", "vliner", "neogeo", NULL, "2001",
 	"V-Liner (v0.54)\0", NULL, "Dyna / BreezaSoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14632,7 +14632,7 @@ static struct BurnRomInfo vliner53RomDesc[] = {
 STDROMPICKEXT(vliner53, vliner53, neogeo)
 STD_ROM_FN(vliner53)
 
-struct BurnDriver BurnDrvvliner53 = {
+struct BurnDriver BurnDrvVliner53 = {
 	"vliner53", "vliner", "neogeo", NULL, "2001",
 	"V-Liner (v0.53)\0", NULL, "Dyna / BreezaSoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14660,7 +14660,7 @@ static struct BurnRomInfo diggermaRomDesc[] = {
 STDROMPICKEXT(diggerma, diggerma, neogeo)
 STD_ROM_FN(diggerma)
 
-struct BurnDriver BurnDrvdiggerma = {
+struct BurnDriver BurnDrvDiggerma = {
 	"diggerma", NULL, "neogeo", NULL, "2000",
 	"Digger Man\0", NULL, "Kyle Hodgetts", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14788,7 +14788,7 @@ static struct BurnRomInfo bangbedpRomDesc[] = {
 STDROMPICKEXT(bangbedp, bangbedp, neogeo)
 STD_ROM_FN(bangbedp)
 
-struct BurnDriver BurnDrvbangbedp = {
+struct BurnDriver BurnDrvBangbedp = {
 	"bangbedp", "bangbead", "neogeo", NULL, "2000",
 	"Bang Bead (Prototype?)\0", NULL, "Visco", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -14859,7 +14859,7 @@ static INT32 DoubledrspInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvdoubledrsp = {
+struct BurnDriver BurnDrvDoubledrsp = {
 	"doubledrsp", "doubledr", "neogeo", NULL, "2023",
 	"Double Dragon (Special 2017, hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15098,7 +15098,7 @@ static struct BurnRomInfo crswd2blRomDesc[] = {
 STDROMPICKEXT(crswd2bl, crswd2bl, neogeo)
 STD_ROM_FN(crswd2bl)
 
-struct BurnDriver BurnDrvcrswd2bl = {
+struct BurnDriver BurnDrvCrswd2bl = {
 	"crswd2bl", NULL, "neogeo", NULL, "1991",
 	"Crossed Swords 2 (bootleg CD to cartridge conversion)\0", NULL, "bootleg (Razoola)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15181,7 +15181,7 @@ static INT32 cthd2k3aInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvcthd2k3a = {
+struct BurnDriver BurnDrvCthd2k3a = {
 	"cthd2k3a", "kof2001", "neogeo", NULL, "2003",
 	"Crouching Tiger Hidden Dragon 2003 (set 2)\0", NULL, "bootleg", "Neo Geo MVS",
 	L"Crouching Tiger Hidden Dragon 2003 (set 2)\0\u81E5\u864E\u85CF\u9F8D\0", NULL, NULL, NULL,
@@ -15209,7 +15209,7 @@ static struct BurnRomInfo froman2bRomDesc[] = {
 STDROMPICKEXT(froman2b, froman2b, neogeo)
 STD_ROM_FN(froman2b)
 
-struct BurnDriver BurnDrvfroman2b = {
+struct BurnDriver BurnDrvFroman2b = {
 	"froman2b", NULL, "neogeo", NULL, "1995",
 	"Idol Mahjong - final romance 2 (Neo CD Conversion)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15239,7 +15239,7 @@ static struct BurnRomInfo totcRomDesc[] = {
 STDROMPICKEXT(totc, totc, neogeo)
 STD_ROM_FN(totc)
 
-struct BurnDriver BurnDrvtotc = {
+struct BurnDriver BurnDrvTotc = {
 	"totc", NULL, "neogeo", NULL, "2011",
 	"Treasure of the Caribbean\0", NULL, "FACE Corporation / N.C.I - Le Cortex", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15275,7 +15275,7 @@ static struct BurnRomInfo kof2000ps2RomDesc[] = {
 STDROMPICKEXT(kof2000ps2, kof2000ps2, neogeo)
 STD_ROM_FN(kof2000ps2)
 
-struct BurnDriver BurnDrvkof2000ps2 = {
+struct BurnDriver BurnDrvKof2000ps2 = {
 	"kof2000ps2", "kof2000", "neogeo", NULL, "2000",
 	"The King of Fighters 2000 (Playstation 2 ver. , EGHT hack)\0", "hack only enable in AES mode", "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15310,7 +15310,7 @@ static struct BurnRomInfo kof2000otcRomDesc[] = {
 STDROMPICKEXT(kof2000otc, kof2000otc, neogeo)
 STD_ROM_FN(kof2000otc)
 
-struct BurnDriver BurnDrvkof2000otc = {
+struct BurnDriver BurnDrvKof2000otc = {
 	"kof2000otc", "kof2000", "neogeo", NULL, "2020-06-15",
 	"The King of Fighters 2000 (OTC, hack)\0", "ZERO only enabled in AES mode", "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15322,80 +15322,80 @@ struct BurnDriver BurnDrvkof2000otc = {
 
 // The King of Fighters 2001 Plus (set 2, bootleg / hack)
 
-static struct BurnRomInfo kf2k1paRomDesc[] = {
-	{ "2k1-p1a.bin",      0x100000, 0xf8a71b6f, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "262-pg2.bin",      0x400000, 0x91eea062, 1 | BRF_ESS | BRF_PRG }, //  1
+static struct BurnRomInfo kf2k1plaRomDesc[] = {
+	{ "2k1-p1pa.bin",		0x100000, 0xf8a71b6f, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "262-pg2.sp2",		0x400000, 0x91eea062, 1 | BRF_ESS | BRF_PRG }, //  1
 	
-	{ "2k1-s1a.bin",      0x020000, 0x50986eeb, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "2k1-s1pa.bin",		0x020000, 0x50986eeb, 2 | BRF_GRA },           //  2 Text layer tiles
 
-	{ "262-c1-08-e0.bin", 0x800000, 0x99cc785a, 3 | BRF_GRA },     		 //  3 Sprite data
-	{ "262-c2-08-e0.bin", 0x800000, 0x50368cbf, 3 | BRF_GRA },     		 //  4 
-	{ "262-c3-08-e0.bin", 0x800000, 0xfb14ff87, 3 | BRF_GRA },     		 //  5 
-	{ "262-c4-08-e0.bin", 0x800000, 0x4397faf8, 3 | BRF_GRA },     		 //  6 
-	{ "262-c5-08-e0.bin", 0x800000, 0x91f24be4, 3 | BRF_GRA },     		 //  7 
-	{ "262-c6-08-e0.bin", 0x800000, 0xa31e4403, 3 | BRF_GRA },     		 //  8 
-	{ "262-c7-08-e0.bin", 0x800000, 0x54d9d1ec, 3 | BRF_GRA },     		 //  9 
-	{ "262-c8-08-e0.bin", 0x800000, 0x59289a6b, 3 | BRF_GRA },     		 // 10 
+	{ "262-c1-08-e0.c1",	0x800000, 0x99cc785a, 3 | BRF_GRA },     		 //  3 Sprite data
+	{ "262-c2-08-e0.c2",	0x800000, 0x50368cbf, 3 | BRF_GRA },     		 //  4 
+	{ "262-c3-08-e0.c3",	0x800000, 0xfb14ff87, 3 | BRF_GRA },     		 //  5 
+	{ "262-c4-08-e0.c4",	0x800000, 0x4397faf8, 3 | BRF_GRA },     		 //  6 
+	{ "262-c5-08-e0.c5",	0x800000, 0x91f24be4, 3 | BRF_GRA },     		 //  7 
+	{ "262-c6-08-e0.c6",	0x800000, 0xa31e4403, 3 | BRF_GRA },     		 //  8 
+	{ "262-c7-08-e0.c7",	0x800000, 0x54d9d1ec, 3 | BRF_GRA },     		 //  9 
+	{ "262-c8-08-e0.c8",	0x800000, 0x59289a6b, 3 | BRF_GRA },     		 // 10 
 
-	{ "265-262-m1.bin",   0x040000, 0xa7f8119f, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+	{ "265-262-m1.m1",		0x040000, 0xa7f8119f, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "262-v1-08-e0.bin", 0x400000, 0x83d49ecf, 5 | BRF_SND },     		 // 12 Sound data
-	{ "262-v2-08-e0.bin", 0x400000, 0x003f1843, 5 | BRF_SND },     		 // 13 
-	{ "262-v3-08-e0.bin", 0x400000, 0x2ae38dbe, 5 | BRF_SND },     		 // 14 
-	{ "262-v4-08-e0.bin", 0x400000, 0x26ec4dd9, 5 | BRF_SND },     		 // 15 
+	{ "262-v1-08-e0.v1",	0x400000, 0x83d49ecf, 5 | BRF_SND },     		 // 12 Sound data
+	{ "262-v2-08-e0.v2",	0x400000, 0x003f1843, 5 | BRF_SND },     		 // 13 
+	{ "262-v3-08-e0.v3",	0x400000, 0x2ae38dbe, 5 | BRF_SND },     		 // 14 
+	{ "262-v4-08-e0.v4",	0x400000, 0x26ec4dd9, 5 | BRF_SND },     		 // 15 
 };
 
-STDROMPICKEXT(kf2k1pa, kf2k1pa, neogeo)
-STD_ROM_FN(kf2k1pa)
+STDROMPICKEXT(kf2k1pla, kf2k1pla, neogeo)
+STD_ROM_FN(kf2k1pla)
 
-static void kf2k1paCallback()
+static void kf2k1plaCallback()
 {
 	for (INT32 i = 0; i < 0x20000; i++) {
 		NeoTextROM[nNeoActiveSlot][i] = BITSWAP08(NeoTextROM[nNeoActiveSlot][i], 3, 2, 4, 5, 1, 6, 0, 7);
 	}	
 }
 
-static INT32 kf2k1paInit()
+static INT32 kf2k1plaInit()
 {
 	nNeoProtectionXor = 0x1e;
-	NeoCallbackActive->pInitialise = kf2k1paCallback;
+	NeoCallbackActive->pInitialise = kf2k1plaCallback;
 
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkf2k1pa = {
-	"kf2k1pa", "kof2001", "neogeo", NULL, "2002",
+struct BurnDriver BurnDrvKf2k1pla = {
+	"kf2k1pla", "kof2001", "neogeo", NULL, "2002",
 	"The King of Fighters 2001 Plus (set 2, bootleg / hack)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_CMC50 | HARDWARE_SNK_ENCRYPTED_M1, GBF_VSFIGHT, FBF_KOF,
-	NULL, kf2k1paRomInfo, kf2k1paRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	kf2k1paInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	NULL, kf2k1plaRomInfo, kf2k1plaRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	kf2k1plaInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 
 // The King of Fighters 2001 Plus (set 1, bootleg / hack)
 
 static struct BurnRomInfo kf2k1plsRomDesc[] = {
-	{ "2k1-p1p.bin",      0x100000, 0x758529a7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "262-pg2.bin",      0x400000, 0x91eea062, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "2k1-p1p.bin",		0x100000, 0x758529a7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "262-pg2.sp2",		0x400000, 0x91eea062, 1 | BRF_ESS | BRF_PRG }, //  1
 	
-	{ "2k1-s1p.bin",      0x020000, 0x088657e6, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "2k1-s1p.bin",		0x020000, 0x088657e6, 2 | BRF_GRA },           //  2 Text layer tiles
 
-	{ "262-c1-08-e0.bin", 0x800000, 0x99cc785a, 3 | BRF_GRA },     		 //  3 Sprite data
-	{ "262-c2-08-e0.bin", 0x800000, 0x50368cbf, 3 | BRF_GRA },     		 //  4 
-	{ "262-c3-08-e0.bin", 0x800000, 0xfb14ff87, 3 | BRF_GRA },     		 //  5 
-	{ "262-c4-08-e0.bin", 0x800000, 0x4397faf8, 3 | BRF_GRA },     		 //  6 
-	{ "262-c5-08-e0.bin", 0x800000, 0x91f24be4, 3 | BRF_GRA },     		 //  7 
-	{ "262-c6-08-e0.bin", 0x800000, 0xa31e4403, 3 | BRF_GRA },     		 //  8 
-	{ "262-c7-08-e0.bin", 0x800000, 0x54d9d1ec, 3 | BRF_GRA },     		 //  9 
-	{ "262-c8-08-e0.bin", 0x800000, 0x59289a6b, 3 | BRF_GRA },     		 // 10 
+	{ "262-c1-08-e0.c1",	0x800000, 0x99cc785a, 3 | BRF_GRA },     		 //  3 Sprite data
+	{ "262-c2-08-e0.c2",	0x800000, 0x50368cbf, 3 | BRF_GRA },     		 //  4 
+	{ "262-c3-08-e0.c3",	0x800000, 0xfb14ff87, 3 | BRF_GRA },     		 //  5 
+	{ "262-c4-08-e0.c4",	0x800000, 0x4397faf8, 3 | BRF_GRA },     		 //  6 
+	{ "262-c5-08-e0.c5",	0x800000, 0x91f24be4, 3 | BRF_GRA },     		 //  7 
+	{ "262-c6-08-e0.c6",	0x800000, 0xa31e4403, 3 | BRF_GRA },     		 //  8 
+	{ "262-c7-08-e0.c7",	0x800000, 0x54d9d1ec, 3 | BRF_GRA },     		 //  9 
+	{ "262-c8-08-e0.c8",	0x800000, 0x59289a6b, 3 | BRF_GRA },     		 // 10 
 
-	{ "265-262-m1.bin",   0x040000, 0xa7f8119f, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+	{ "265-262-m1.m1",		0x040000, 0xa7f8119f, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "262-v1-08-e0.bin", 0x400000, 0x83d49ecf, 5 | BRF_SND },     		 // 12 Sound data
-	{ "262-v2-08-e0.bin", 0x400000, 0x003f1843, 5 | BRF_SND },     		 // 13 
-	{ "262-v3-08-e0.bin", 0x400000, 0x2ae38dbe, 5 | BRF_SND },     		 // 14 
-	{ "262-v4-08-e0.bin", 0x400000, 0x26ec4dd9, 5 | BRF_SND },     		 // 15 
+	{ "262-v1-08-e0.v1",	0x400000, 0x83d49ecf, 5 | BRF_SND },     		 // 12 Sound data
+	{ "262-v2-08-e0.v2",	0x400000, 0x003f1843, 5 | BRF_SND },     		 // 13 
+	{ "262-v3-08-e0.v3",	0x400000, 0x2ae38dbe, 5 | BRF_SND },     		 // 14 
+	{ "262-v4-08-e0.v4",	0x400000, 0x26ec4dd9, 5 | BRF_SND },     		 // 15 
 };
 
 STDROMPICKEXT(kf2k1pls, kf2k1pls, neogeo)
@@ -15408,7 +15408,7 @@ static INT32 kf2k1plsInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkf2k1pls = {
+struct BurnDriver BurnDrvKf2k1pls = {
 	"kf2k1pls", "kof2001", "neogeo", NULL, "2002",
 	"The King of Fighters 2001 Plus (set 1, bootleg / hack)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15421,30 +15421,30 @@ struct BurnDriver BurnDrvkf2k1pls = {
 // The King of Fighters 2002 Plus (bootleg set 3)
 
 static struct BurnRomInfo kf2k2plbRomDesc[] = {
-	{ "2k2-p1p.bin",  0x100000, 0x3ab03781, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "265-p2.bin",   0x400000, 0x327266b8, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "2k2-p1p.bin",	0x100000, 0x3ab03781, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "265-p2.sp2",		0x400000, 0x327266b8, 1 | BRF_ESS | BRF_PRG }, //  1 
 
-	{ "2k2-s1pb.bin", 0x020000, 0x2072d5e9, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "2k2-s1pb.bin",	0x020000, 0x2072d5e9, 2 | BRF_GRA },           //  2 Text layer tiles
 
-	{ "265-c1.bin",   0x800000, 0x2b65a656, 3 | BRF_GRA },           //  3 Sprite data
-	{ "265-c2.bin",   0x800000, 0xadf18983, 3 | BRF_GRA },           //  4 
-	{ "265-c3.bin",   0x800000, 0x875e9fd7, 3 | BRF_GRA },           //  5 
-	{ "265-c4.bin",   0x800000, 0x2da13947, 3 | BRF_GRA },           //  6 
-	{ "265-c5.bin",   0x800000, 0x61bd165d, 3 | BRF_GRA },           //  7 
-	{ "265-c6.bin",   0x800000, 0x03fdd1eb, 3 | BRF_GRA },           //  8 
-	{ "265-c7.bin",   0x800000, 0x1a2749d8, 3 | BRF_GRA },           //  9 
-	{ "265-c8.bin",   0x800000, 0xab0bb549, 3 | BRF_GRA },           // 10 
+	{ "265-c1.c1",		0x800000, 0x2b65a656, 3 | BRF_GRA },           //  3 Sprite data
+	{ "265-c2.c2",		0x800000, 0xadf18983, 3 | BRF_GRA },           //  4 
+	{ "265-c3.c3",		0x800000, 0x875e9fd7, 3 | BRF_GRA },           //  5 
+	{ "265-c4.c4",		0x800000, 0x2da13947, 3 | BRF_GRA },           //  6 
+	{ "265-c5.c5",		0x800000, 0x61bd165d, 3 | BRF_GRA },           //  7 
+	{ "265-c6.c6",		0x800000, 0x03fdd1eb, 3 | BRF_GRA },           //  8 
+	{ "265-c7.c7",		0x800000, 0x1a2749d8, 3 | BRF_GRA },           //  9 
+	{ "265-c8.c8",		0x800000, 0xab0bb549, 3 | BRF_GRA },           // 10 
 
-	{ "265-m1.bin",   0x020000, 0x85aaa632, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+	{ "265-m1.m1",		0x020000, 0x85aaa632, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "265-v1.bin",   0x800000, 0x15e8f3f5, 5 | BRF_SND },           // 12 Sound data
-	{ "265-v2.bin",   0x800000, 0xda41d6f9, 5 | BRF_SND },           // 13 
+	{ "265-v1.v1",		0x800000, 0x15e8f3f5, 5 | BRF_SND },           // 12 Sound data
+	{ "265-v2.v2",		0x800000, 0xda41d6f9, 5 | BRF_SND },           // 13 
 };
 
 STDROMPICKEXT(kf2k2plb, kf2k2plb, neogeo)
 STD_ROM_FN(kf2k2plb)
 
-struct BurnDriver BurnDrvkf2k2plb = {
+struct BurnDriver BurnDrvKf2k2plb = {
 	"kf2k2plb", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 2002 Plus (bootleg set 3)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15457,24 +15457,24 @@ struct BurnDriver BurnDrvkf2k2plb = {
 // The King of Fighters 2002 Super (bootleg)
 
 static struct BurnRomInfo kf2k2plcRomDesc[] = {
-	{ "2k2-p1pc.bin", 0x100000, 0xebedae17, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "265-p2.bin",   0x400000, 0x327266b8, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "2k2-p1pc.bin",	0x100000, 0xebedae17, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "265-p2.sp2",		0x400000, 0x327266b8, 1 | BRF_ESS | BRF_PRG }, //  1 
 
-	{ "2k2-s1pc.bin", 0x020000, 0xfecbb589, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "2k2-s1pc.bin",	0x020000, 0xfecbb589, 2 | BRF_GRA },           //  2 Text layer tiles
 
-	{ "265-c1.bin",   0x800000, 0x2b65a656, 3 | BRF_GRA },           //  3 Sprite data
-	{ "265-c2.bin",   0x800000, 0xadf18983, 3 | BRF_GRA },           //  4 
-	{ "265-c3.bin",   0x800000, 0x875e9fd7, 3 | BRF_GRA },           //  5 
-	{ "265-c4.bin",   0x800000, 0x2da13947, 3 | BRF_GRA },           //  6 
-	{ "265-c5.bin",   0x800000, 0x61bd165d, 3 | BRF_GRA },           //  7 
-	{ "265-c6.bin",   0x800000, 0x03fdd1eb, 3 | BRF_GRA },           //  8 
-	{ "265-c7.bin",   0x800000, 0x1a2749d8, 3 | BRF_GRA },           //  9 
-	{ "265-c8.bin",   0x800000, 0xab0bb549, 3 | BRF_GRA },           // 10 
+	{ "265-c1.c1",		0x800000, 0x2b65a656, 3 | BRF_GRA },           //  3 Sprite data
+	{ "265-c2.c2",		0x800000, 0xadf18983, 3 | BRF_GRA },           //  4 
+	{ "265-c3.c3",		0x800000, 0x875e9fd7, 3 | BRF_GRA },           //  5 
+	{ "265-c4.c4",		0x800000, 0x2da13947, 3 | BRF_GRA },           //  6 
+	{ "265-c5.c5",		0x800000, 0x61bd165d, 3 | BRF_GRA },           //  7 
+	{ "265-c6.c6",		0x800000, 0x03fdd1eb, 3 | BRF_GRA },           //  8 
+	{ "265-c7.c7",		0x800000, 0x1a2749d8, 3 | BRF_GRA },           //  9 
+	{ "265-c8.c8",		0x800000, 0xab0bb549, 3 | BRF_GRA },           // 10 
 
-	{ "265-m1.bin",   0x020000, 0x85aaa632, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+	{ "265-m1.m1",		0x020000, 0x85aaa632, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "265-v1.bin",   0x800000, 0x15e8f3f5, 5 | BRF_SND },           // 12 Sound data
-	{ "265-v2.bin",   0x800000, 0xda41d6f9, 5 | BRF_SND },           // 13 
+	{ "265-v1.v1",		0x800000, 0x15e8f3f5, 5 | BRF_SND },           // 12 Sound data
+	{ "265-v2.v2",		0x800000, 0xda41d6f9, 5 | BRF_SND },           // 13 
 };
 
 STDROMPICKEXT(kf2k2plc, kf2k2plc, neogeo)
@@ -15505,7 +15505,7 @@ static INT32 kf2k2plcInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkf2k2plc = {
+struct BurnDriver BurnDrvKf2k2plc = {
 	"kf2k2plc", "kof2002", "neogeo", NULL, "2002",
 	"The King of Fighters 2002 Super (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15534,37 +15534,22 @@ static struct BurnRomInfo kf2k2ps2RomDesc[] = {
 	{ "265-c9ps2o.c9",		0x800000, 0xaa8bbc97, 3 | BRF_GRA },           // 11
 	{ "265-c10ps2o.c10",	0x800000, 0x9832713d, 3 | BRF_GRA },           // 12 
 
-	{ "265-m1.m1",			0x020000, 0x85aaa632, 4 | BRF_ESS | BRF_PRG }, // 13 Z80 code
+	{ "265-m1d.m1",			0x020000, 0x1c661a4b, 4 | BRF_ESS | BRF_PRG }, // 13 Z80 code
 
-	{ "265-v1.v1",			0x800000, 0x15e8f3f5, 5 | BRF_SND },           // 14 Sound data
-	{ "265-v2.v2",			0x800000, 0xda41d6f9, 5 | BRF_SND },           // 15
+	{ "265-v1d.v1",			0x800000, 0x0fc9a58d, 5 | BRF_SND },           // 14 Sound data
+	{ "265-v2d.v2",			0x800000, 0xb8c475a4, 5 | BRF_SND },           // 15 
 };
 
 STDROMPICKEXT(kf2k2ps2, kf2k2ps2, neogeo)
 STD_ROM_FN(kf2k2ps2)
 
-static INT32 kf2k2ps2Init()
-{
-	INT32 nRet;
-
-	nRet = NeoInit();
-
-	if (nRet == 0) {
-		const PCM2DecryptV2Info Info = { 0xa5000, 0x000000, { 0xf9, 0xe0, 0x5d, 0xf3, 0xea, 0x92, 0xbe, 0xef } };
-
-		PCM2DecryptV2(&Info);
-	}
-
-	return nRet;
-}
-
-struct BurnDriver BurnDrvkf2k2ps2 = {
+struct BurnDriver BurnDrvKf2k2ps2 = {
 	"kf2k2ps2", "kof2002", "neogeo", NULL, "2007",
 	"The King of Fighters 2002 (PlayStation 2 ver 0.4, EGHT hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_ENCRYPTED_M1, GBF_VSFIGHT, FBF_KOF,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
 	NULL, kf2k2ps2RomInfo, kf2k2ps2RomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	kf2k2ps2Init, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 
@@ -15596,7 +15581,7 @@ static struct BurnRomInfo kf2k2ps2bRomDesc[] = {
 STDROMPICKEXT(kf2k2ps2b, kf2k2ps2b, neogeo)
 STD_ROM_FN(kf2k2ps2b)
 
-struct BurnDriver BurnDrvkf2k2ps2b = {
+struct BurnDriver BurnDrvKf2k2ps2b = {
 	"kf2k2ps2b", "kof2002", "neogeo", NULL, "2018",
 	"The King of Fighters 2002 (PlayStation 2, Hack)\0", "hack only enable in AES mode", "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15670,7 +15655,7 @@ static INT32 kf2k4plsInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkf2k4pls = {
+struct BurnDriver BurnDrvKf2k4pls = {
 	"kf2k4pls", "kof2002", "neogeo", NULL, "2004",
 	"The King of Fighters Special Edition 2004 Plus (bootleg)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -15868,7 +15853,7 @@ static INT32 kof2k2omgInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkof2k2omg = {
+struct BurnDriver BurnDrvKof2k2omg = {
 	"kof2k2omg", "kof2002", "neogeo", NULL, "2002",
 	"Kof2002 (hack omg)\0", NULL, "bootleg", "KOF-ON Team",
 	NULL, NULL, NULL, NULL,
@@ -15904,7 +15889,7 @@ static struct BurnRomInfo kof2k2omg8RomDesc[] = {
 STDROMPICKEXT(kof2k2omg8, kof2k2omg8, neogeo)
 STD_ROM_FN(kof2k2omg8)
 
-struct BurnDriver BurnDrvkof2k2omg8 = {
+struct BurnDriver BurnDrvKof2k2omg8 = {
 	"kof2k2omg8", "kof2002", "neogeo", NULL, "2010",
 	"Kof2002 (Omega v0.8)\0", NULL, "bootleg", "KOF-ON Team",
 	NULL, NULL, NULL, NULL,
@@ -15942,7 +15927,7 @@ static struct BurnRomInfo kof2k2omg9bRomDesc[] = {
 STDROMPICKEXT(kof2k2omg9b, kof2k2omg9b, neogeo)
 STD_ROM_FN(kof2k2omg9b)
 
-struct BurnDriver BurnDrvkof2k2omg9b = {
+struct BurnDriver BurnDrvKof2k2omg9b = {
 	"kof2k2omg9b", "kof2002", "neogeo", NULL, "2011",
 	"Kof2002 (Omega v0.9 beta)\0", NULL, "bootleg", "KOF-ON Team",
 	NULL, NULL, NULL, NULL,
@@ -15980,7 +15965,7 @@ static struct BurnRomInfo kof2k2omg9RomDesc[] = {
 STDROMPICKEXT(kof2k2omg9, kof2k2omg9, neogeo)
 STD_ROM_FN(kof2k2omg9)
 
-struct BurnDriver BurnDrvkof2k2omg9 = {
+struct BurnDriver BurnDrvKof2k2omg9 = {
 	"kof2k2omg9", "kof2002", "neogeo", NULL, "2012",
 	"Kof2002 (Omega v0.9)\0", NULL, "bootleg", "KOF-ON Team",
 	NULL, NULL, NULL, NULL,
@@ -16030,7 +16015,7 @@ static INT32 kof2k2plusInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof2k2plus = {
+struct BurnDriver BurnDrvKof2k2plus = {
 	"kof2k2plus", "kof2002", "neogeo", NULL, "2020",
 	"The King of Fighters 2002 (Plus 2017, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16113,7 +16098,7 @@ static struct BurnRomInfo kof96aeRomDesc[] = {
 STDROMPICKEXT(kof96ae, kof96ae, neogeo)
 STD_ROM_FN(kof96ae)
 
-struct BurnDriver BurnDrvkof96ae = {
+struct BurnDriver BurnDrvKof96ae = {
 	"kof96ae", "kof96", "neogeo", NULL, "2007",
 	"The King of Fighters '96 (Anniversary Edition, EGHT hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16127,7 +16112,7 @@ struct BurnDriver BurnDrvkof96ae = {
 
 static struct BurnRomInfo kof96ae20RomDesc[] = {
 	{ "214-p1ae.p1",	0x100000, 0xc718ea76, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "214-p2ae.p2",	0x400000, 0x2638be07, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "214-p2ae.sp2",	0x400000, 0x2638be07, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "214-s1ae.s1",	0x020000, 0xb9626494, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -16148,7 +16133,7 @@ static struct BurnRomInfo kof96ae20RomDesc[] = {
 STDROMPICKEXT(kof96ae20, kof96ae20, neogeo)
 STD_ROM_FN(kof96ae20)
 
-struct BurnDriver BurnDrvkof96ae20 = {
+struct BurnDriver BurnDrvKof96ae20 = {
 	"kof96ae20", "kof96", "neogeo", NULL, "2019",
 	"The King of Fighters '96 (The Anniversary Edition 2.0, Build 2.3.0320)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16188,7 +16173,7 @@ static struct BurnRomInfo kof96cnRomDesc[] = {
 STDROMPICKEXT(kof96cn, kof96cn, neogeo)
 STD_ROM_FN(kof96cn)
 
-struct BurnDriver BurnDrvkof96cn = {
+struct BurnDriver BurnDrvKof96cn = {
 	"kof96cn", "kof96", "neogeo", NULL, "200?",
 	"The King of Fighters '96 (Chinese Edition ver 1.0, hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16226,7 +16211,7 @@ static struct BurnRomInfo kof96rssRomDesc[] = {
 STDROMPICKEXT(kof96rss, kof96rss, neogeo)
 STD_ROM_FN(kof96rss)
 
-struct BurnDriver BurnDrvkof96rss = {
+struct BurnDriver BurnDrvKof96rss = {
 	"kof96rss", "kof96", "neogeo", NULL, "2005",
 	"The King of Fighters '96 Remix Spring Special (Hack, Version 1.5)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16289,7 +16274,7 @@ static INT32 kof96epInit()
  	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkof96ep = {
+struct BurnDriver BurnDrvKof96ep = {
 	"kof96ep", "kof96", "neogeo", NULL, "1996",
 	"The King of Fighters '96 (bootleg / hack)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16324,7 +16309,7 @@ static struct BurnRomInfo kof97cnRomDesc[] = {
 STDROMPICKEXT(kof97cn, kof97cn, neogeo)
 STD_ROM_FN(kof97cn)
 
-struct BurnDriver BurnDrvkof97cn = {
+struct BurnDriver BurnDrvKof97cn = {
 	"kof97cn", "kof97", "neogeo", NULL, "2007",
 	"The King of Fighters '97 (10th Anniversary Chinese Edition, EGHT hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16371,7 +16356,7 @@ static INT32 kof97plaInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvkof97pla = {
+struct BurnDriver BurnDrvKof97pla = {
 	"kof97pla", "kof97", "neogeo", NULL, "2003",
 	"The King of Fighters '97 Plus 2003 (bootleg / hack)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16481,7 +16466,7 @@ static struct BurnRomInfo kof97xtRomDesc[] = {
 STDROMPICKEXT(kof97xt, kof97xt, neogeo)
 STD_ROM_FN(kof97xt)
 
-struct BurnDriver BurnDrvkof97xt = {
+struct BurnDriver BurnDrvKof97xt = {
 	"kof97xt", "kof97", "neogeo", NULL, "2007",
 	"The King of Fighters '97 - Final Battle (hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16516,7 +16501,7 @@ static struct BurnRomInfo kof97tRomDesc[] = {
 STDROMPICKEXT(kof97t, kof97t, neogeo)
 STD_ROM_FN(kof97t)
 
-struct BurnDriver BurnDrvkof97t = {
+struct BurnDriver BurnDrvKof97t = {
 	"kof97t", "kof97", "neogeo", NULL, "2020",
 	"The King of Fighters '97 Random Select Optimized Edition (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16555,7 +16540,7 @@ static struct BurnRomInfo kof97aeRomDesc[] = {
 STDROMPICKEXT(kof97ae, kof97ae, neogeo)
 STD_ROM_FN(kof97ae)
 
-struct BurnDriver BurnDrvkof97ae = {
+struct BurnDriver BurnDrvKof97ae = {
 	"kof97ae", "kof97", "neogeo", NULL, "2018",
 	"The King of Fighters '97 - Anniversary Edition (Build 2.1.0212)\0", NULL, "EGHT", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16614,7 +16599,7 @@ static struct BurnRomInfo kof98aeRomDesc[] = {
 //	{ "242-p1ae.bin",	0x100000, 0xc9188c66, 1 | BRF_ESS | BRF_PRG }, //  0 68K code 
 	{ "242-p1aeo.p1",	0x100000, 0x23a80b3e, 1 | BRF_ESS | BRF_PRG }, //  0 68K code 
 //	{ "242-p2ae.bin",	0x600000, 0x609fac6b, 1 | BRF_ESS | BRF_PRG }, //  1 
-	{ "242-p2aeo.sp1",	0x600000, 0x99b3e5cc, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "242-p2aeo.sp2",	0x600000, 0x99b3e5cc, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "242-s1aeo.s1",	0x020000, 0xf1fee5c0, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -16643,7 +16628,7 @@ static struct BurnRomInfo kof98aeRomDesc[] = {
 STDROMPICKEXT(kof98ae, kof98ae, neogeo)
 STD_ROM_FN(kof98ae)
 
-struct BurnDriver BurnDrvkof98ae = {
+struct BurnDriver BurnDrvKof98ae = {
 	"kof98ae", "kof98", "neogeo", NULL, "2007",
 	"The King of Fighters '98 (Anniversary Edition, EGHT hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16690,7 +16675,7 @@ static struct BurnRomInfo kof98ae2016RomDesc[] = {
 STDROMPICKEXT(kof98ae2016, kof98ae2016, neogeo)
 STD_ROM_FN(kof98ae2016)
 
-struct BurnDriver BurnDrvkof98ae2016 = {
+struct BurnDriver BurnDrvKof98ae2016 = {
 	"kof98ae2016", "kof98", "neogeo", NULL, "2016",
 	"The King of Fighters '98 (Anniversary Edition build 1.2.0827)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16729,7 +16714,7 @@ static struct BurnRomInfo kof98cbRomDesc[] = {
 STDROMPICKEXT(kof98cb, kof98cb, neogeo)
 STD_ROM_FN(kof98cb)
 
-struct BurnDriver BurnDrvkof98cb = {
+struct BurnDriver BurnDrvKof98cb = {
 	"kof98cb", "kof98", "neogeo", NULL, "2018",
 	"The King of Fighters '98 (Combo, hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16767,7 +16752,7 @@ static struct BurnRomInfo kof98ultRomDesc[] = {
 	{ "242-v2.v2",		0x400000, 0xcc11106e, 5 | BRF_SND },           // 17
 	{ "242-v3.v3",		0x400000, 0x044ea4e1, 5 | BRF_SND },           // 18
 	{ "242-v4.v4",		0x400000, 0x7985ea30, 5 | BRF_SND },           // 19
-	{ "242-v5ae.v4",	0x400000, 0xafdd9660, 5 | BRF_SND },           // 20
+	{ "242-v5ae.v5",	0x400000, 0xafdd9660, 5 | BRF_SND },           // 20
 };
 
 STDROMPICKEXT(kof98ult, kof98ult, neogeo)
@@ -16818,7 +16803,7 @@ static struct BurnRomInfo kof99aeRomDesc[] = {
 STDROMPICKEXT(kof99ae, kof99ae, neogeo)
 STD_ROM_FN(kof99ae)
 
-struct BurnDriver BurnDrvkof99ae = {
+struct BurnDriver BurnDrvKof99ae = {
 	"kof99ae", "kof99", "neogeo", NULL, "2017",
 	"The King of Fighters '99 Anniversary Edition (hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -16858,7 +16843,7 @@ static struct BurnRomInfo lastbladaRomDesc[] = {
 STDROMPICKEXT(lastblada, lastblada, neogeo)
 STD_ROM_FN(lastblada)
 
-struct BurnDriver BurnDrvlastblada = {
+struct BurnDriver BurnDrvLastblada = {
 	"lastblada", "lastblad", "neogeo", NULL, "1997",
 	"The Last Blade / Bakumatsu Roman - Gekka no Kenshi (NGM-2340, alternate board)\0", NULL, "SNK", "Neo Geo MVS",
 	L"The Last Blade\0\u5E55\u672B\u6D6A\u6F2B \u6708\u83EF\u306E\u5263\u58EB (NGM-2340, alternate board)\0", NULL, NULL, NULL,
@@ -16868,14 +16853,14 @@ struct BurnDriver BurnDrvlastblada = {
 	0x1000, 320, 224, 4, 3
 };
 
-// The Last Blade / Bakumatsu Roman - Gekka no Kenshi (Special 2017, Hack)
+// The Last Blade / Bakumatsu Roman - Gekka no Kenshi (Special 2017 v2.5 Final, Hack)
 // Modified by GSC2007
-// Version number: Ver 2.0-FINAL
+// GOTVG 20250117
 
 static struct BurnRomInfo lastbladspRomDesc[] = {
-	{ "234-p1sp.p1",	0x100000, 0x264f191b, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "234-p2sp.sp2",	0x600000, 0x6e5914ce, 1 | BRF_ESS | BRF_PRG }, //  1
-	{ "234-p3sp.p3",	0x020000, 0xd6a50f04, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
+	{ "234-p1sp.p1",	0x100000, 0x977753ce, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "234-p2sp.sp2",	0x600000, 0x4a2a92fc, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "234-p3sp.p3",	0x020000, 0xd5fbd2dc, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	{ "234-s1.s1",		0x020000, 0x95561412, 2 | BRF_GRA },           //  3 Text layer tiles
 
@@ -16899,6 +16884,7 @@ STD_ROM_FN(lastbladsp)
 
 static void LastbladspPatchCallback()
 {
+#if 0
 	UINT16* rom = (UINT16*)Neo68KROMActive;
 
 	for (INT32 i = 0; i < 0x100000 >> 1; i++) {
@@ -16920,7 +16906,7 @@ static void LastbladspPatchCallback()
 
 //	rom[0x11036 >> 1] = 0x4e75; // lbsp v1.1 fix, thanks HBMAME :)
 	rom[0x1102c >> 1] = 0x4e75; // lbsp v2.0 fix
-
+#endif
 }
 
 static INT32 LastbladspInit()
@@ -16933,10 +16919,10 @@ static INT32 LastbladspInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvlastbladsp = {
-	"lastbladsp", "lastblad", "neogeo", NULL, "2023",
-	"The Last Blade / Bakumatsu Roman - Gekka no Kenshi (Special 2017, Hack)\0", NULL, "hack", "Neo Geo MVS",
-	L"The Last Blade\0\u5E55\u672B\u6D6A\u6F2B \u6708\u83EF\u306E\u5263\u58EB (Special 2017, Hack)\0", NULL, NULL, NULL,
+struct BurnDriver BurnDrvLastbladsp = {
+	"lastbladsp", "lastblad", "neogeo", NULL, "2025",
+	"The Last Blade / Bakumatsu Roman - Gekka no Kenshi (Special 2017 v2.5 Final, Hack)\0", NULL, "hack (GSC2007)", "Neo Geo MVS",
+	L"The Last Blade\0\u5E55\u672B\u6D6A\u6F2B \u6708\u83EF\u306E\u5263\u58EB (Special 2017 v2.5 Final, Hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, 0,
 	NULL, lastbladspRomInfo, lastbladspRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	LastbladspInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
@@ -16971,7 +16957,7 @@ static struct BurnRomInfo lastbld2ehRomDesc[] = {
 STDROMPICKEXT(lastbld2eh, lastbld2eh, neogeo)
 STD_ROM_FN(lastbld2eh)
 
-struct BurnDriver BurnDrvDlastbld2eh = {
+struct BurnDriver BurnDrvLastbld2eh = {
 	"lastbld2eh", "lastbld2", "neogeo", NULL, "1998",
 	"The Last Blade 2 / Bakumatsu Roman - Dai Ni Maku Gekka no Kenshi (Enhanced Hack)\0", NULL, "SNK", "Neo Geo MVS",
 	L"The Last Blade 2\0\u5E55\u672B\u6D6A\u6F2B\u7B2C\u4E8C\u5E55 - \u6708\u83EF\u306E\u5263\u58EB - \u6708\u306B\u54B2\u304F\u83EF\u3001\u6563\u308A\u3086\u304F\u82B1 (Enhanced Hack)\0", NULL, NULL, NULL,
@@ -17009,9 +16995,9 @@ static struct BurnRomInfo lastbld2teRomDesc[] = {
 STDROMPICKEXT(lastbld2te, lastbld2te, neogeo)
 STD_ROM_FN(lastbld2te)
 
-struct BurnDriver BurnDrvDlastbld2te = {
+struct BurnDriver BurnDrvLastbld2te = {
 	"lastbld2te", "lastbld2", "neogeo", NULL, "1998",
-	"The Last Blade 2 / Bakumatsu Roman - Dai Ni Maku Gekka no Kenshi (Team Edition Hack)\0", NULL, "SNK", "Neo Geo MVS",
+	"The Last Blade 2 / Bakumatsu Roman - Dai Ni Maku Gekka no Kenshi (Team Edition Hack)\0", NULL, "hack", "Neo Geo MVS",
 	L"The Last Blade 2\0\u5E55\u672B\u6D6A\u6F2B\u7B2C\u4E8C\u5E55 - \u6708\u83EF\u306E\u5263\u58EB - \u6708\u306B\u54B2\u304F\u83EF\u3001\u6563\u308A\u3086\u304F\u82B1 (Team Edition Hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, 0,
 	NULL, lastbld2teRomInfo, lastbld2teRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
@@ -17041,7 +17027,7 @@ static struct BurnRomInfo lhcdbRomDesc[] = {
 STDROMPICKEXT(lhcdb, lhcdb, neogeo)
 STD_ROM_FN(lhcdb)
 
-struct BurnDriver BurnDrvlhcdb = {
+struct BurnDriver BurnDrvLhcdb = {
 	"lhcdb", NULL, "neogeo", NULL, "2007",
 	"Last Hope CD Beta (Neo CD conversion)\0", "Imperfect graphics", "NG:Dev.Team", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17074,7 +17060,7 @@ static struct BurnRomInfo lasthopeRomDesc[] = {
 STDROMPICKEXT(lasthope, lasthope, neogeo)
 STD_ROM_FN(lasthope)
 
-struct BurnDriver BurnDrvlasthope = {
+struct BurnDriver BurnDrvLasthope = {
 	"lasthope", NULL, "neogeo", NULL, "2005",
 	"Last Hope (bootleg AES to MVS conversion, no coin support)\0", NULL, "NG:Dev.Team", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17107,7 +17093,7 @@ static struct BurnRomInfo mslug2tRomDesc[] = {
 STDROMPICKEXT(mslug2t, mslug2t, neogeo)
 STD_ROM_FN(mslug2t)
 
-struct BurnDriver BurnDrvMSlug2t = {
+struct BurnDriver BurnDrvMslug2t = {
 	"mslug2t", "mslug2", "neogeo", NULL, "2015",
 	"Metal Slug 2 Turbo (NGM-9410) (hack)\0", NULL, "hack (trap15)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17143,7 +17129,7 @@ static struct BurnRomInfo mslug3vRomDesc[] = {
 STDROMPICKEXT(mslug3v, mslug3v, neogeo)
 STD_ROM_FN(mslug3v)
 
-struct BurnDriver BurnDrvmslug3v = {
+struct BurnDriver BurnDrvMslug3v = {
 	"mslug3v", "mslug3", "neogeo", NULL, "2012",
 	"Metal Slug 3 (NGH-2560) (Enhanced Violence Version hack by EEZEZY)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17220,7 +17206,7 @@ static INT32 mslug5bInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvmslug5b = {
+struct BurnDriver BurnDrvMslug5b = {
 	"mslug5b", "mslug5", "neogeo", NULL, "2003",
 	"Metal Slug 5 (bootleg, set 1)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17288,7 +17274,7 @@ static INT32 mslug5b2Init()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvmslug5b2 = {
+struct BurnDriver BurnDrvMslug5b2 = {
 	"mslug5b2", "mslug5", "neogeo", NULL, "2003",
 	"Metal Slug 5 (bootleg, set 2)\0", NULL, "bootleg", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17325,7 +17311,7 @@ static struct BurnRomInfo samshoaRomDesc[] = {
 STDROMPICKEXT(samshoa, samshoa, neogeo)
 STD_ROM_FN(samshoa)
 
-struct BurnDriver BurnDrvSamShoa = {
+struct BurnDriver BurnDrvSamshoa = {
 	"samshoa", "samsho", "neogeo", NULL, "1993",
 	"Samurai Shodown / Samurai Spirits (NGM-045, alternate board)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17366,7 +17352,7 @@ static struct BurnRomInfo samsho2spRomDesc[] = {
 STDROMPICKEXT(samsho2sp, samsho2sp, neogeo)
 STD_ROM_FN(samsho2sp)
 
-static INT32 Samsho2spInit()
+static INT32 samsho2spInit()
 {
     INT32 nRet = NeoInit();
 	if (0 == nRet) NeoMapExtraRom(0x200000, 0x20000);
@@ -17380,15 +17366,15 @@ struct BurnDriver BurnDrvSamsho2sp = {
 	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Special 2017, hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
 	NULL, samsho2spRomInfo, samsho2spRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	Samsho2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	samsho2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 320, 224, 4, 3
 };
 
-// Samurai Shodown II Perfect Hack v. 2.3 - 2024-09-07
+// Samurai Shodown II Perfect Hack v. 2.4 - 2025-01-27
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",	0x100000, 0x184c3a6c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "063-p2pe.sp2",	0x100000, 0x025ee4ed, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "063-p1pe.p1",	0x100000, 0x20625a12, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p2pe.sp2",	0x100000, 0x231c4e31, 1 | BRF_ESS | BRF_PRG }, //  1
 	{ "063-p3pe.p3",	0x020000, 0x82ce7ad7, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	{ "063-s1.s1",		0x020000, 0x64a5cd66, 2 | BRF_GRA },           //  3 Text layer tiles
@@ -17414,12 +17400,12 @@ STDROMPICKEXT(samsho2pe, samsho2pe, neogeo)
 STD_ROM_FN(samsho2pe)
 
 struct BurnDriver BurnDrvSamsho2pe = {
-	"samsho2pe", "samsho2", "neogeo", NULL, "2024",
-	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Perfect V. 2.3, hack)\0", NULL, "hack (Bear)", "Neo Geo MVS",
-	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.3, hack)\0", NULL, NULL, NULL,
+	"samsho2pe", "samsho2", "neogeo", NULL, "2025",
+	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Perfect V. 2.4, hack)\0", NULL, "hack (Bear)", "Neo Geo MVS",
+	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.4, hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
 	NULL, samsho2peRomInfo, samsho2peRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	Samsho2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	samsho2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 320, 224, 4, 3
 };
 
@@ -17431,28 +17417,28 @@ static struct BurnRomInfo samsho4spRomDesc[] = {
 	{ "222-p1sp.p1",  0x100000, 0x6e98579a, 1 | BRF_ESS | BRF_PRG }, //  0 68K code			
 	{ "222-p2sp.sp2", 0x400000, 0x2c9c64db, 1 | BRF_ESS | BRF_PRG }, //  1 					
 
-	{ "222-s1.s1",    0x020000, 0x8d3d3bf9, 2 | BRF_GRA },           //  2 Text layer tiles /* TC531000 */
+	{ "222-s1.s1",    0x020000, 0x8d3d3bf9, 2 | BRF_GRA },           //  2 Text layer tiles
 
-	{ "222-c1.c1",    0x400000, 0x68f2ed95, 3 | BRF_GRA },           //  3 Sprite data		/* TC5332205 */
-	{ "222-c2.c2",    0x400000, 0xa6e9aff0, 3 | BRF_GRA },           //  4 					/* TC5332205 */
-	{ "222-c3.c3",    0x400000, 0xc91b40f4, 3 | BRF_GRA },           //  5 					/* TC5332205 */
-	{ "222-c4.c4",    0x400000, 0x359510a4, 3 | BRF_GRA },           //  6 					/* TC5332205 */
-	{ "222-c5.c5",    0x400000, 0x9cfbb22d, 3 | BRF_GRA },           //  7 					/* TC5332205 */
-	{ "222-c6.c6",    0x400000, 0x685efc32, 3 | BRF_GRA },           //  8 					/* TC5332205 */
-	{ "222-c7sp.c7",  0x400000, 0xecb13c24, 3 | BRF_GRA },           //  9 					
-	{ "222-c8sp.c8",  0x400000, 0x0f9a0bda, 3 | BRF_GRA },           // 10 					
+	{ "222-c1.c1",    0x400000, 0x68f2ed95, 3 | BRF_GRA },           //  3 Sprite data
+	{ "222-c2.c2",    0x400000, 0xa6e9aff0, 3 | BRF_GRA },           //  4
+	{ "222-c3.c3",    0x400000, 0xc91b40f4, 3 | BRF_GRA },           //  5
+	{ "222-c4.c4",    0x400000, 0x359510a4, 3 | BRF_GRA },           //  6
+	{ "222-c5.c5",    0x400000, 0x9cfbb22d, 3 | BRF_GRA },           //  7
+	{ "222-c6.c6",    0x400000, 0x685efc32, 3 | BRF_GRA },           //  8
+	{ "222-c7sp.c7",  0x400000, 0xecb13c24, 3 | BRF_GRA },           //  9
+	{ "222-c8sp.c8",  0x400000, 0x0f9a0bda, 3 | BRF_GRA },           // 10
 
-	{ "222-m1.m1",    0x020000, 0x7615bc1b, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code			/* TC531001 */
+	{ "222-m1.m1",    0x020000, 0x7615bc1b, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "222-v1.v1",    0x400000, 0x7d6ba95f, 5 | BRF_SND },           // 12 Sound data		/* TC5332204 */
-	{ "222-v2.v2",    0x400000, 0x6c33bb5d, 5 | BRF_SND },           // 13 					/* TC5332204 */
-	{ "222-v3.v3",    0x200000, 0x831ea8c0, 5 | BRF_SND },           // 14 					/* TC5316200 */
+	{ "222-v1.v1",    0x400000, 0x7d6ba95f, 5 | BRF_SND },           // 12 Sound data
+	{ "222-v2.v2",    0x400000, 0x6c33bb5d, 5 | BRF_SND },           // 13
+	{ "222-v3.v3",    0x200000, 0x831ea8c0, 5 | BRF_SND },           // 14
 };
 
 STDROMPICKEXT(samsho4sp, samsho4sp, neogeo)
 STD_ROM_FN(samsho4sp)
 
-struct BurnDriver BurnDrvSamSho4sp = {
+struct BurnDriver BurnDrvSamsho4sp = {
 	"samsho4sp", "samsho4", "neogeo", NULL, "1996",
 	"Samurai Shodown IV - Amakusa's Revenge / Samurai Spirits - Amakusa Kourin (Special 2017, hack)\0", NULL, "hack", "Neo Geo MVS",
 	L"Samurai Shodown IV - Amakusa's Revenge\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4 - \u5929\u8349\u964D\u81E8 (Special 2017, hack)\0", NULL, NULL, NULL,
@@ -17465,29 +17451,29 @@ struct BurnDriver BurnDrvSamSho4sp = {
 // Samurai Shodown V / Samurai Spirits Zero (hack of XBOX version)
 
 static struct BurnRomInfo samsho5xRomDesc[] = {
-	{ "ssvx_p1.rom",  0x800000, 0x16983af9, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "ssvx_p1.rom",	0x800000, 0x16983af9, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 		
-	{ "ssv_s1.rom",   0x020000, 0x2ad6048b, 2 | BRF_GRA },           //  1 Text layer tiles
+	{ "270-s1d.s1",		0x020000, 0x2ad6048b, 2 | BRF_GRA },           //  1 Text layer tiles
 
-	{ "ssvx_c1.rom",  0x800000, 0x25272e50, 3 | BRF_GRA },           //  2 Sprite data
-	{ "ssvx_c2.rom",  0x800000, 0xba68f2e7, 3 | BRF_GRA },           //  3 
-	{ "ssvx_c3.rom",  0x800000, 0x75883cde, 3 | BRF_GRA },           //  4 
-	{ "ssvx_c4.rom",  0x800000, 0x348540e6, 3 | BRF_GRA },           //  5 
-	{ "ssvx_c5.rom",  0x800000, 0x1fee8dc8, 3 | BRF_GRA },           //  6
-	{ "ssvx_c6.rom",  0x800000, 0xc300b50d, 3 | BRF_GRA },           //  7
-	{ "ssvx_c7.rom",  0x800000, 0x5e722b0b, 3 | BRF_GRA },           //  8
-	{ "ssvx_c8.rom",  0x800000, 0xe2a2c546, 3 | BRF_GRA },           //  9
+	{ "270-c1x.c1",		0x800000, 0x25272e50, 3 | BRF_GRA },           //  2 Sprite data
+	{ "270-c2x.c2",		0x800000, 0xba68f2e7, 3 | BRF_GRA },           //  3 
+	{ "270-c3x.c3",		0x800000, 0x75883cde, 3 | BRF_GRA },           //  4 
+	{ "270-c4x.c4",		0x800000, 0x348540e6, 3 | BRF_GRA },           //  5 
+	{ "270-c5x.c5",		0x800000, 0x1fee8dc8, 3 | BRF_GRA },           //  6
+	{ "270-c6x.c6",		0x800000, 0xc300b50d, 3 | BRF_GRA },           //  7
+	{ "270-c7x.c7",		0x800000, 0x5e722b0b, 3 | BRF_GRA },           //  8
+	{ "270-c8x.c8",		0x800000, 0xe2a2c546, 3 | BRF_GRA },           //  9
 
-	{ "ssvx_m1.rom",  0x080000, 0x5218a10a, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
+	{ "270-m1d.m1",		0x080000, 0x5218a10a, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
 
-	{ "ssv_v1.rom",   0x800000, 0x809c7617, 5 | BRF_SND },           // 11 Sound data
-	{ "ssv_v2.rom",   0x800000, 0x42671607, 5 | BRF_SND },           // 12 
+	{ "270-v1d.v1",		0x800000, 0x809c7617, 5 | BRF_SND },           // 11 Sound data
+	{ "270-v2d.v2",		0x800000, 0x42671607, 5 | BRF_SND },           // 12 
 };
 
 STDROMPICKEXT(samsho5x, samsho5x, neogeo)
 STD_ROM_FN(samsho5x)
 
-struct BurnDriver BurnDrvsamsho5x = {
+struct BurnDriver BurnDrvSamsho5x = {
 	"samsho5x", "samsho5", "neogeo", NULL, "2003",
 	"Samurai Shodown V / Samurai Spirits Zero (hack of XBOX version)\0", NULL, "hack", "Neo Geo MVS",
 	L"Samurai Shodown V\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 (hack of XBOX version)\0", NULL, NULL, NULL,
@@ -17522,7 +17508,7 @@ static struct BurnRomInfo samsh5pfRomDesc[] = {
 STDROMPICKEXT(samsh5pf, samsh5pf, neogeo)
 STD_ROM_FN(samsh5pf)
 
-struct BurnDriver BurnDrvsamsh5pf = {
+struct BurnDriver BurnDrvSamsh5pf = {
 	"samsh5pf", "samsh5sp", "neogeo", NULL, "2020",
 	"Samurai Shodown V Perfect / Samurai Spirits Zero Perfect (bootleg, hack)\0", NULL, "bootleg", "Neo Geo MVS",
 	L"Samurai Shodown V Perfect\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4\u96F6 Perfect (bootleg, hack)\0", NULL, NULL, NULL,
@@ -17620,7 +17606,7 @@ static struct BurnRomInfo wh2jaRomDesc[] = {
 STDROMPICKEXT(wh2ja, wh2ja, neogeo)
 STD_ROM_FN(wh2ja)
 
-struct BurnDriver BurnDrvwh2ja = {
+struct BurnDriver BurnDrvWh2ja = {
 	"wh2ja", "wh2j", "neogeo", NULL, "1994",
 	"World Heroes 2 Jet (ADM-007)\0", NULL, "ADK / SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17648,7 +17634,7 @@ static struct BurnRomInfo zintrkcdRomDesc[] = {
 STDROMPICKEXT(zintrkcd, zintrkcd, neogeo)
 STD_ROM_FN(zintrkcd)
 
-struct BurnDriver BurnDrvzintrkcd = {
+struct BurnDriver BurnDrvZintrkcd = {
 	"zintrkcd", "zintrckb", "neogeo", NULL, "1996",
 	"Zintrick / Oshidashi Zentrix (Neo CD conversion)\0", NULL, "hack", "Neo Geo MVS",
 	L"Zintrick\0\u62BC\u3057\u51FA\u3057\u30B8\u30F3\u30C8\u30EA\u30C3\u30AF (Neo CD conversion)\0", NULL, NULL, NULL,
@@ -17710,7 +17696,7 @@ static struct BurnRomInfo beastRomDesc[] = {
 STDROMPICKEXT(beast, beast, neogeo)
 STD_ROM_FN(beast)
 
-struct BurnDriver BurnDrvbeast = {
+struct BurnDriver BurnDrvBeast = {
 	"beast", NULL, "neogeo", NULL, "????",
 	"Shadow of the Beast (Neo Geo demo)\0", NULL, "Jeff Kurtz", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17738,7 +17724,7 @@ static struct BurnRomInfo cnbeRomDesc[] = {
 STDROMPICKEXT(cnbe, cnbe, neogeo)
 STD_ROM_FN(cnbe)
 
-struct BurnDriver BurnDrvcnbe = {
+struct BurnDriver BurnDrvCnbe = {
 	"cnbe", NULL, "neogeo", NULL, "2006",
 	"Codename - Blut Engel (2006-01-19)\0", NULL, "blastar@gmx.net", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17766,7 +17752,7 @@ static struct BurnRomInfo columnsnRomDesc[] = {
 STDROMPICKEXT(columnsn, columnsn, neogeo)
 STD_ROM_FN(columnsn)
 
-struct BurnDriver BurnDrvcolumnsn = {
+struct BurnDriver BurnDrvColumnsn = {
 	"columnsn", NULL, "neogeo", NULL, "????",
 	"Columns (Neo Geo)\0", NULL, "homebrew", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17794,7 +17780,7 @@ static struct BurnRomInfo ltorb1RomDesc[] = {
 STDROMPICKEXT(ltorb1, ltorb1, neogeo)
 STD_ROM_FN(ltorb1)
 
-struct BurnDriver BurnDrvltorb1 = {
+struct BurnDriver BurnDrvLtorb1 = {
 	"ltorb1", NULL, "neogeo", NULL, "2005",
 	"Jonas Indiana and the Lost Temple of RA (20050717)\0", NULL, "blastar@gmx.net", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17822,7 +17808,7 @@ static struct BurnRomInfo neo2500RomDesc[] = {
 STDROMPICKEXT(neo2500, neo2500, neogeo)
 STD_ROM_FN(neo2500)
 
-struct BurnDriver BurnDrvneo2500 = {
+struct BurnDriver BurnDrvNeo2500 = {
 	"neo2500", NULL, "neogeo", NULL, "2004",
 	"Neo 2500 Demo\0", NULL, "blastar@gmx.net", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17849,7 +17835,7 @@ static struct BurnRomInfo neodemoRomDesc[] = {
 STDROMPICKEXT(neodemo, neodemo, neogeo)
 STD_ROM_FN(neodemo)
 
-struct BurnDriver BurnDrvneodemo = {
+struct BurnDriver BurnDrvNeodemo = {
 	"neodemo", NULL, "neogeo", NULL, "2002",
 	"Chaos Demo (Neo Geo)\0", NULL, "Chaos", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17877,7 +17863,7 @@ static struct BurnRomInfo neonoponRomDesc[] = {
 STDROMPICKEXT(neonopon, neonopon, neogeo)
 STD_ROM_FN(neonopon)
 
-struct BurnDriver BurnDrvneonopon = {
+struct BurnDriver BurnDrvNeonopon = {
 	"neonopon", NULL, "neogeo", NULL, "????",
 	"Neo No Panepon (beta)\0", NULL, "blastar@gmx.net", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17905,7 +17891,7 @@ static struct BurnRomInfo neopongRomDesc[] = {
 STDROMPICKEXT(neopong, neopong, neogeo)
 STD_ROM_FN(neopong)
 
-struct BurnDriver BurnDrvneopong = {
+struct BurnDriver BurnDrvNeopong = {
 	"neopong", NULL, "neogeo", NULL, "2002",
 	"Neo Pong (ver 1.1)\0", NULL, "Neo Dev Corporation", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17940,7 +17926,7 @@ static INT32 neopongaInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvneoponga = {
+struct BurnDriver BurnDrvNeoponga = {
 	"neoponga", "neopong", "neogeo", NULL, "2002",
 	"Neo Pong (ver 1.0)\0", NULL, "Neo Dev Corporation", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17968,7 +17954,7 @@ static struct BurnRomInfo ngem2kRomDesc[] = {
 STDROMPICKEXT(ngem2k, ngem2k, neogeo)
 STD_ROM_FN(ngem2k)
 
-struct BurnDriver BurnDrvngem2k = {
+struct BurnDriver BurnDrvNgem2k = {
 	"ngem2k", NULL, "neogeo", NULL, "2006",
 	"NGEM2K (beta 2006-01-18)\0", NULL, "homebrew", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -17999,7 +17985,7 @@ static struct BurnRomInfo ngfrogRomDesc[] = {
 STDROMPICKEXT(ngfrog, ngfrog, neogeo)
 STD_ROM_FN(ngfrog)
 
-struct BurnDriver BurnDrvngfrog = {
+struct BurnDriver BurnDrvNgfrog = {
 	"ngfrog", NULL, "neogeo", NULL, "2006",
 	"Frog Feast (Neo Geo)\0", NULL, "Rastersoft", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18027,7 +18013,7 @@ static struct BurnRomInfo poknightRomDesc[] = {
 STDROMPICKEXT(poknight, poknight, neogeo)
 STD_ROM_FN(poknight)
 
-struct BurnDriver BurnDrvpoknight = {
+struct BurnDriver BurnDrvPoknight = {
 	"poknight", NULL, "neogeo", NULL, "????",
 	"Poker Night\0", NULL, "Jeff Kurtz", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18055,7 +18041,7 @@ static struct BurnRomInfo syscheckRomDesc[] = {
 STDROMPICKEXT(syscheck, syscheck, neogeo)
 STD_ROM_FN(syscheck)
 
-struct BurnDriver BurnDrvsyscheck = {
+struct BurnDriver BurnDrvSyscheck = {
 	"syscheck", NULL, "neogeo", NULL, "????",
 	"Neo System Check (ver 1.0b)\0", NULL, "blastar@gmx.net", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18089,7 +18075,7 @@ static struct BurnRomInfo cndiRomDesc[] = {
 STDROMPICKEXT(cndi, cndi, neogeo)
 STD_ROM_FN(cndi)
 
-struct BurnDriver BurnDrvcndi = {
+struct BurnDriver BurnDrvCndi = {
 	"cndi", NULL, "neogeo", NULL, "2009",
 	"Chip n Dale (Intro demo)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18123,7 +18109,7 @@ static struct BurnRomInfo dwiRomDesc[] = {
 STDROMPICKEXT(dwi, dwi, neogeo)
 STD_ROM_FN(dwi)
 
-struct BurnDriver BurnDrvdwi = {
+struct BurnDriver BurnDrvDwi = {
 	"dwi", NULL, "neogeo", NULL, "2009",
 	"DarkWing Duck (Intro demo)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18157,7 +18143,7 @@ static struct BurnRomInfo dwiaRomDesc[] = {
 STDROMPICKEXT(dwia, dwia, neogeo)
 STD_ROM_FN(dwia)
 
-struct BurnDriver BurnDrvdwia = {
+struct BurnDriver BurnDrvDwia = {
 	"dwia", "dwi", "neogeo", NULL, "2009",
 	"DarkWing Duck (Intro demo, alt)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18191,7 +18177,7 @@ static struct BurnRomInfo duckiRomDesc[] = {
 STDROMPICKEXT(ducki, ducki, neogeo)
 STD_ROM_FN(ducki)
 
-struct BurnDriver BurnDrvducki = {
+struct BurnDriver BurnDrvDucki = {
 	"ducki", NULL, "neogeo", NULL, "2009",
 	"Duck Tales (Intro demo)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18224,7 +18210,7 @@ static struct BurnRomInfo ghostbiRomDesc[] = {
 STDROMPICKEXT(ghostbi, ghostbi, neogeo)
 STD_ROM_FN(ghostbi)
 
-struct BurnDriver BurnDrvghostbi = {
+struct BurnDriver BurnDrvGhostbi = {
 	"ghostbi", NULL, "neogeo", NULL, "2009",
 	"Ghost Busters (Intro demo)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18258,7 +18244,7 @@ static struct BurnRomInfo robocopiRomDesc[] = {
 STDROMPICKEXT(robocopi, robocopi, neogeo)
 STD_ROM_FN(robocopi)
 
-struct BurnDriver BurnDrvrobocopi = {
+struct BurnDriver BurnDrvRobocopi = {
 	"robocopi", NULL, "neogeo", NULL, "2009",
 	"Robocop (Intro demo)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18291,7 +18277,7 @@ static struct BurnRomInfo spidermiRomDesc[] = {
 STDROMPICKEXT(spidermi, spidermi, neogeo)
 STD_ROM_FN(spidermi)
 
-struct BurnDriver BurnDrvspidermi = {
+struct BurnDriver BurnDrvSpidermi = {
 	"spidermi", NULL, "neogeo", NULL, "2009",
 	"Spiderman (Intro demo)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18325,7 +18311,7 @@ static struct BurnRomInfo tmntiRomDesc[] = {
 STDROMPICKEXT(tmnti, tmnti, neogeo)
 STD_ROM_FN(tmnti)
 
-struct BurnDriver BurnDrvtmnti = {
+struct BurnDriver BurnDrvTmnti = {
 	"tmnti", NULL, "neogeo", NULL, "2009",
 	"Teenage Mutant Ninja Turtles (Intro demo)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18359,7 +18345,7 @@ static struct BurnRomInfo tmntiaRomDesc[] = {
 STDROMPICKEXT(tmntia, tmntia, neogeo)
 STD_ROM_FN(tmntia)
 
-struct BurnDriver BurnDrvtmntia = {
+struct BurnDriver BurnDrvTmntia = {
 	"tmntia", "tmnti", "neogeo", NULL, "2009",
 	"Teenage Mutant Ninja Turtles (Intro demo, alt)\0", "You must use the Universe BIOS and set region to Japan AES", "Sergi", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18388,7 +18374,7 @@ static struct BurnRomInfo neothndrRomDesc[] = {
 STDROMPICKEXT(neothndr, neothndr, neogeo)
 STD_ROM_FN(neothndr)
 
-struct BurnDriver BurnDrvneothndr = {
+struct BurnDriver BurnDrvNeothndr = {
 	"neothndr", NULL, "neogeo", NULL, "2012",
 	"Neo Thunder\0", "sebastianmihai.com", "Sebastian Mihai", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18417,7 +18403,7 @@ static struct BurnRomInfo ngftdemoRomDesc[] = {
 STDROMPICKEXT(ngftdemo, ngftdemo, neogeo)
 STD_ROM_FN(ngftdemo)
 
-struct BurnDriver BurnDrvngftdemo = {
+struct BurnDriver BurnDrvNgftdemo = {
 	"ngftdemo", NULL, "neogeo", NULL, "2012",
 	"NGF Transparency Demo\0", "redarmor.net", "CeL", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18446,7 +18432,7 @@ static struct BurnRomInfo neocstlvRomDesc[] = {
 STDROMPICKEXT(neocstlv, neocstlv, neogeo)
 STD_ROM_FN(neocstlv)
 
-struct BurnDriver BurnDrvneocstlv = {
+struct BurnDriver BurnDrvNeocstlv = {
 	"neocstlv", NULL, "neogeo", NULL, "2004",
 	"Neo CastleVania Demo\0", NULL, "Barf/BarfHappy", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18474,7 +18460,7 @@ static struct BurnRomInfo neo3ddmoRomDesc[] = {
 STDROMPICKEXT(neo3ddmo, neo3ddmo, neogeo)
 STD_ROM_FN(neo3ddmo)
 
-struct BurnDriver BurnDrvneo3ddmo = {
+struct BurnDriver BurnDrvNeo3ddmo = {
 	"neo3ddmo", NULL, "neogeo", NULL, "2012",
 	"NeoGeo 3D! Demo\0", NULL, "Oxygene", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18503,7 +18489,7 @@ static struct BurnRomInfo neoww2RomDesc[] = {
 STDROMPICKEXT(neoww2, neoww2, neogeo)
 STD_ROM_FN(neoww2)
 
-struct BurnDriver BurnDrvneoww2 = {
+struct BurnDriver BurnDrvNeoww2 = {
 	"neoww2", NULL, "neogeo", NULL, "2012",
 	"WW2 Demo - Arcade Development Project\0", NULL, "Charles DOTY/RasterSoft (USA)", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18533,7 +18519,7 @@ static struct BurnRomInfo timesupdRomDesc[] = {
 STDROMPICKEXT(timesupd, timesupd, neogeo)
 STD_ROM_FN(timesupd)
 
-struct BurnDriver BurnDrvtimesupd = {
+struct BurnDriver BurnDrvTimesupd = {
 	"timesupd", NULL, "neogeo", NULL, "2012",
 	"Time's Up Demo\0", NULL, "NGF Dev. Inc.", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18562,7 +18548,7 @@ static struct BurnRomInfo neogalagRomDesc[] = {
 STDROMPICKEXT(neogalag, neogalag, neogeo)
 STD_ROM_FN(neogalag)
 
-struct BurnDriver BurnDrvneogalag = {
+struct BurnDriver BurnDrvNeogalag = {
 	"neogalag", NULL, "neogeo", NULL, "2013",
 	"Galaga Demo (set 1)\0", NULL, "Cristiano Bei/www.iocerom.com", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18591,7 +18577,7 @@ static struct BurnRomInfo neogalagaRomDesc[] = {
 STDROMPICKEXT(neogalaga, neogalaga, neogeo)
 STD_ROM_FN(neogalaga)
 
-struct BurnDriver BurnDrvneogalaga = {
+struct BurnDriver BurnDrvNeogalaga = {
 	"neogalaga", "neogalag", "neogeo", NULL, "2013",
 	"Galaga Demo (set 2)\0", NULL, "Cristiano Bei/www.iocerom.com", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18620,7 +18606,7 @@ static struct BurnRomInfo neotetRomDesc[] = {
 STDROMPICKEXT(neotet, neotet, neogeo)
 STD_ROM_FN(neotet)
 
-struct BurnDriver BurnDrvneotet = {
+struct BurnDriver BurnDrvNeotet = {
 	"neotet", NULL, "neogeo", NULL, "2013",
 	"NeoGeo 2-Player Tetris\0", NULL, "Crim/Stephen", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18649,7 +18635,7 @@ static struct BurnRomInfo neoprimoRomDesc[] = {
 STDROMPICKEXT(neoprimo, neoprimo, neogeo)
 STD_ROM_FN(neoprimo)
 
-struct BurnDriver BurnDrvneoprimo = {
+struct BurnDriver BurnDrvNeoprimo = {
 	"neoprimo", NULL, "neogeo", NULL, "2013",
 	"Primo Demo\0", NULL, "iocerom.com", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18690,7 +18676,7 @@ static INT32 CphdInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvcphd = {
+struct BurnDriver BurnDrvCphd = {
 	"cphd", NULL, "neogeo", NULL, "2013",
 	"Crouching Poney Hidden Dragon (DEMO)\0", NULL, "Le Cortex", "Neo Geo",
 	NULL, NULL, NULL, NULL,
@@ -18719,7 +18705,7 @@ static struct BurnRomInfo badappleRomDesc[] = {
 STDROMPICKEXT(badapple, badapple, neogeo)
 STD_ROM_FN(badapple)
 
-struct BurnDriver BurnDrvbadapple = {
+struct BurnDriver BurnDrvBadapple = {
 	"badapple", NULL, "neogeo", NULL, "2017",
 	"Bad Apple Demo\0", NULL, "Hpman", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18761,7 +18747,7 @@ static INT32 neonInit()
 	return NeoInit();
 }
 
-struct BurnDriver BurnDrvneon = {
+struct BurnDriver BurnDrvNeon = {
 	"neon", NULL, "neogeo", NULL, "2019",
 	"Project Neon - Caravan Demo (0.4.19)\0", NULL, "FULLSET", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -18776,26 +18762,26 @@ struct BurnDriver BurnDrvneon = {
 // Modified by 磁暴线圈
 
 static struct BurnRomInfo mslug5wRomDesc[] = {
-	{ "268-p1w.p1",    0x100000, 0xb0c126da, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "268-p2w.p2",    0x400000, 0xf06c589a, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "268-p1w.p1",		0x100000, 0xb0c126da, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "268-p2w.p2",		0x400000, 0xf06c589a, 1 | BRF_ESS | BRF_PRG }, //  1
 	
-	{ "268-s1d.s1",    0x020000, 0x64952683, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },           //  2 Text layer tiles
 
-	{ "268-c1d.c1",    0x800000, 0xe8239365, 3 | BRF_GRA },           //  3 Sprite data
-	{ "268-c2d.c2",    0x800000, 0x89b21d4c, 3 | BRF_GRA },           //  4
-	{ "268-c3d.c3",    0x800000, 0x3cda13a0, 3 | BRF_GRA },           //  5
-	{ "268-c4d.c4",    0x800000, 0x9c00160d, 3 | BRF_GRA },           //  6
-	{ "268-c5w.c5",    0x800000, 0x483a986c, 3 | BRF_GRA },           //  7
-	{ "268-c6w.c6",    0x800000, 0xd918f796, 3 | BRF_GRA },           //  8
-	{ "268-c7w.c7",    0x800000, 0xbdb9a887, 3 | BRF_GRA },           //  9
-	{ "268-c8w.c8",    0x800000, 0x6f8ac6fb, 3 | BRF_GRA },           // 10
+	{ "268-c1d.c1",		0x800000, 0xe8239365, 3 | BRF_GRA },           //  3 Sprite data
+	{ "268-c2d.c2",		0x800000, 0x89b21d4c, 3 | BRF_GRA },           //  4
+	{ "268-c3d.c3",		0x800000, 0x3cda13a0, 3 | BRF_GRA },           //  5
+	{ "268-c4d.c4",		0x800000, 0x9c00160d, 3 | BRF_GRA },           //  6
+	{ "268-c5w.c5",		0x800000, 0x483a986c, 3 | BRF_GRA },           //  7
+	{ "268-c6w.c6",		0x800000, 0xd918f796, 3 | BRF_GRA },           //  8
+	{ "268-c7w.c7",		0x800000, 0xbdb9a887, 3 | BRF_GRA },           //  9
+	{ "268-c8w.c8",		0x800000, 0x6f8ac6fb, 3 | BRF_GRA },           // 10
 
-	{ "268-m1w.m1",    0x080000, 0x464c72ad, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+	{ "268-m1w.m1",		0x080000, 0x464c72ad, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "268-v1w.v1",    0x400000, 0xa8e12a92, 5 | BRF_SND },           // 12 Sound data
-	{ "268-v2w.v2",    0x400000, 0x0608cba3, 5 | BRF_SND },           // 13
-	{ "268-v3d.v3",    0x400000, 0x02fd519e, 5 | BRF_SND },           // 14
-	{ "268-v4w.v4",    0x4002f0, 0x179cbca3, 5 | BRF_SND },           // 15
+	{ "268-v1w.v1",		0x400000, 0xa8e12a92, 5 | BRF_SND },           // 12 Sound data
+	{ "268-v2w.v2",		0x400000, 0x0608cba3, 5 | BRF_SND },           // 13
+	{ "268-v3nd.v3",	0x400000, 0x02fd519e, 5 | BRF_SND },           // 14
+	{ "268-v4w.v4",		0x4002f0, 0x179cbca3, 5 | BRF_SND },           // 15
 };
 
 STDROMPICKEXT(mslug5w, mslug5w, neogeo)
@@ -18919,7 +18905,7 @@ static INT32 kof98pfeInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof98pfe = {
+struct BurnDriver BurnDrvKof98pfe = {
 	"kof98pfe", "kof98", "neogeo", NULL, "2017",
 	"The King of Fighters '98 (Plus Final Edition 2017-07-23)\0", NULL, "hack", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
@@ -18996,7 +18982,7 @@ static struct BurnRomInfo kof98eck20RomDesc[] = {
 STDROMPICKEXT(kof98eck20, kof98eck20, neogeo)
 STD_ROM_FN(kof98eck20)
 
-struct BurnDriver BurnDrvkof98eck20 = {
+struct BurnDriver BurnDrvKof98eck20 = {
 	"kof98eck20", "kof98", "neogeo", NULL, "2020-04-09",
 	"The King of Fighters '98 - Easy Combo King (Version 2020-04-09, hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19037,7 +19023,7 @@ static struct BurnRomInfo kof10thdRomDesc[] = {
 STDROMPICKEXT(kof10thd, kof10thd, neogeo)
 STD_ROM_FN(kof10thd)
 
-struct BurnDriver BurnDrvkof10thd = {
+struct BurnDriver BurnDrvKof10thd = {
 	"kof10thd", "kof2002", "neogeo", NULL, "200?",
 	"Kof 10th Anniversary (The King of Fighters 2002 bootleg / Fully Decrypted)\0", NULL, "hack", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
@@ -19069,7 +19055,7 @@ static struct BurnRomInfo mslugdgRomDesc[] = {
 STDROMPICKEXT(mslugdg, mslugdg, neogeo)
 STD_ROM_FN(mslugdg)
 
-struct BurnDriver BurnDrvmslugdg = {
+struct BurnDriver BurnDrvMslugdg = {
 	"mslugdg", "mslug", "neogeo", NULL, "2018",
 	"Metal Slug (Multifunction, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19102,7 +19088,7 @@ static struct BurnRomInfo mslug2dgRomDesc[] = {
 STDROMPICKEXT(mslug2dg, mslug2dg, neogeo)
 STD_ROM_FN(mslug2dg)
 
-struct BurnDriver BurnDrvmslug2dg = {
+struct BurnDriver BurnDrvMslug2dg = {
 	"mslug2dg", "mslug2", "neogeo", NULL, "2017",
 	"Metal Slug 2 (Multifunction, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19116,32 +19102,30 @@ struct BurnDriver BurnDrvmslug2dg = {
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug3gRomDesc[] = {
-	{ "256-ph1g.p1",    0x100000, 0xb23bd9b7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2g.sp2",   0x400000, 0x8053a3fb, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1g.p1",	0x100000, 0xb23bd9b7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2g.sp2",	0x400000, 0x8053a3fb, 1 | BRF_ESS | BRF_PRG }, //  1 
 
-	{ "256-s1g.s1",     0x020000, 0xaf90d166, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
+	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
+	{ "256-c3d.c3",		0x800000, 0xbfaade82, 3 | BRF_GRA },           //  4
+	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },           //  5
+	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },           //  6
+	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },           //  7
+	{ "256-c7g.c7",		0x800000, 0xca494d38, 3 | BRF_GRA },           //  8
+	{ "256-c8g.c8",		0x800000, 0xe37dc636, 3 | BRF_GRA },           //  9
 
-	{ "256-c1d.c1",     0x800000, 0x3540398c, 3 | BRF_GRA },           //  3 Sprite data
-	{ "256-c2d.c2",     0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  4
-	{ "256-c3d.c3",     0x800000, 0xbfaade82, 3 | BRF_GRA },           //  5
-	{ "256-c4d.c4",     0x800000, 0x1463add6, 3 | BRF_GRA },           //  6
-	{ "256-c5d.c5",     0x800000, 0x48ca7f28, 3 | BRF_GRA },           //  7
-	{ "256-c6d.c6",     0x800000, 0x806eb36f, 3 | BRF_GRA },           //  8
-	{ "256-c7dc.c7",    0x800000, 0xed559fac, 3 | BRF_GRA },           //  9
-	{ "256-c8dc.c8",    0x800000, 0x1c52378b, 3 | BRF_GRA },           // 10
+	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
 
-	{ "256-m1.m1",      0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
-
-	{ "256-v1.v1",		0x400000, 0xf2690241, 5 | BRF_SND },           // 12 Sound data
-	{ "256-v2.v2",		0x400000, 0x7e2a10bd, 5 | BRF_SND },           // 13
-	{ "256-v3.v3",		0x400000, 0x0eaec17c, 5 | BRF_SND },           // 14
-	{ "256-v4.v4",		0x400000, 0x9b4b22d4, 5 | BRF_SND },           // 15
+	{ "256-v1.v1",		0x400000, 0xf2690241, 5 | BRF_SND },           // 11 Sound data
+	{ "256-v2.v2",		0x400000, 0x7e2a10bd, 5 | BRF_SND },           // 12
+	{ "256-v3.v3",		0x400000, 0x0eaec17c, 5 | BRF_SND },           // 13
+	{ "256-v4.v4",		0x400000, 0x9b4b22d4, 5 | BRF_SND },           // 14
 };
 
 STDROMPICKEXT(mslug3g, mslug3g, neogeo)
 STD_ROM_FN(mslug3g)
 
-struct BurnDriver BurnDrvmslug3g = {
+struct BurnDriver BurnDrvMslug3g = {
 	"mslug3g", "mslug3", "neogeo", NULL, "2019",
 	"Metal Slug 3 (Multifunction, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19178,7 +19162,7 @@ static struct BurnRomInfo mslug3cRomDesc[] = {
 STDROMPICKEXT(mslug3c, mslug3c, neogeo)
 STD_ROM_FN(mslug3c)
 
-struct BurnDriver BurnDrvmslug3c = {
+struct BurnDriver BurnDrvMslug3c = {
 	"mslug3c", "mslug3", "neogeo", NULL, "2019",
 	"Metal Slug 3 (Enemy Remix, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19224,7 +19208,7 @@ static INT32 mslug3decCInit()
 	return NeoSMAInit(mslug3SMADecrypt, mslug3WriteWordBankswitch, 0, 0);
 }
 
-struct BurnDriver BurnDrvmslug3eb = {
+struct BurnDriver BurnDrvMslug3eb = {
 	"mslug3eb", "mslug3", "neogeo", NULL, "2013",
 	"Metal Slug 3 (Extreme Blue, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19262,7 +19246,7 @@ static struct BurnRomInfo mslug3lwRomDesc[] = {
 STDROMPICKEXT(mslug3lw, mslug3lw, neogeo)
 STD_ROM_FN(mslug3lw)
 
-struct BurnDriver BurnDrvmslug3lw = {
+struct BurnDriver BurnDrvMslug3lw = {
 	"mslug3lw", "mslug3", "neogeo", NULL, "2023",
 	"Metal Slug 3 (Pigeon Bullet, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19299,7 +19283,7 @@ static struct BurnRomInfo mslug4dgRomDesc[] = {
 STDROMPICKEXT(mslug4dg, mslug4dg, neogeo)
 STD_ROM_FN(mslug4dg)
 
-struct BurnDriver BurnDrvmslug4dg = {
+struct BurnDriver BurnDrvMslug4dg = {
 	"mslug4dg", "mslug4", "neogeo", NULL, "2017",
 	"Metal Slug 4 (Multifunction, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19336,7 +19320,7 @@ static struct BurnRomInfo mslug4lwRomDesc[] = {
 STDROMPICKEXT(mslug4lw, mslug4lw, neogeo)
 STD_ROM_FN(mslug4lw)
 
-struct BurnDriver BurnDrvmslug4lw = {
+struct BurnDriver BurnDrvMslug4lw = {
 	"mslug4lw", "mslug4", "neogeo", NULL, "2023",
 	"Metal Slug 4 (Last Bullet Remix, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19373,7 +19357,7 @@ static struct BurnRomInfo mslug4aRomDesc[] = {
 STDROMPICKEXT(mslug4a, mslug4a, neogeo)
 STD_ROM_FN(mslug4a)
 
-struct BurnDriver BurnDrvmslug4a = {
+struct BurnDriver BurnDrvMslug4a = {
 	"mslug4a", "mslug4", "neogeo", NULL, "2022",
 	"Metal Slug 4 (20th Anniversary, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19412,7 +19396,7 @@ static struct BurnRomInfo mslug5dRomDesc[] = {
 STDROMPICKEXT(mslug5d, mslug5d, neogeo)
 STD_ROM_FN(mslug5d)
 
-struct BurnDriver BurnDrvmslug5d = {
+struct BurnDriver BurnDrvMslug5d = {
 	"mslug5d", "mslug5", "neogeo", NULL, "2017",
 	"Metal Slug 5 (Multifunction, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19450,7 +19434,7 @@ static struct BurnRomInfo mslug5cRomDesc[] = {
 STDROMPICKEXT(mslug5c, mslug5c, neogeo)
 STD_ROM_FN(mslug5c)
 
-struct BurnDriver BurnDrvmslug5c = {
+struct BurnDriver BurnDrvMslug5c = {
 	"mslug5c", "mslug5", "neogeo", NULL, "2019",
 	"Metal Slug 5 (Enemy Remix, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19488,7 +19472,7 @@ static struct BurnRomInfo mslug5xRomDesc[] = {
 STDROMPICKEXT(mslug5x, mslug5x, neogeo)
 STD_ROM_FN(mslug5x)
 
-struct BurnDriver BurnDrvmslug5x = {
+struct BurnDriver BurnDrvMslug5x = {
 	"mslug5x", "mslug5", "neogeo", NULL, "2022",
 	"Metal Slug 5 (X, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19526,7 +19510,7 @@ static struct BurnRomInfo mslug5mgRomDesc[] = {
 STDROMPICKEXT(mslug5mg, mslug5mg, neogeo)
 STD_ROM_FN(mslug5mg)
 
-struct BurnDriver BurnDrvmslug5mg = {
+struct BurnDriver BurnDrvMslug5mg = {
 	"mslug5mg", "mslug5", "neogeo", NULL, "2019",
 	"Metal Slug 5 (Devil Enemy Remix, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19564,7 +19548,7 @@ static struct BurnRomInfo mslug5sgfRomDesc[] = {
 STDROMPICKEXT(mslug5sgf, mslug5sgf, neogeo)
 STD_ROM_FN(mslug5sgf)
 
-struct BurnDriver BurnDrvmslug5sgf = {
+struct BurnDriver BurnDrvMslug5sgf = {
 	"mslug5sgf", "mslug5", "neogeo", NULL, "2021",
 	"Metal Slug 5 (Remake FC2, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19601,7 +19585,7 @@ static struct BurnRomInfo kof97rcRomDesc[] = {
 STDROMPICKEXT(kof97rc, kof97rc, neogeo)
 STD_ROM_FN(kof97rc)
 
-struct BurnDriver BurnDrvkof97rc = {
+struct BurnDriver BurnDrvKof97rc = {
 	"kof97rc", "kof97", "neogeo", NULL, "2019",
 	"The King of Fighters '97 - Random Combo (Hack, Ver. 2010)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19614,17 +19598,17 @@ struct BurnDriver BurnDrvkof97rc = {
 // The King of Fighters '97 - Combo Training Version 2018 (Hack)
 
 static struct BurnRomInfo kof97cbtRomDesc[] = {
-	{ "232-p1cbt.bin",	0x100000, 0x323e4263, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "232-p2cbt.bin",	0x400000, 0x91c0cfdb, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "232-p1cbt.p1",	0x100000, 0x323e4263, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "232-p2cbt.sp2",	0x400000, 0x91c0cfdb, 1 | BRF_ESS | BRF_PRG }, //  1
 
-	{ "232-s1cbt.bin",	0x020000, 0xd4957067, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "232-s1cbt.s1",	0x020000, 0xd4957067, 2 | BRF_GRA },           //  2 Text layer tiles
 
-	{ "232-c1cbt.bin",	0x800000, 0xea16b711, 3 | BRF_GRA },           //  3 Sprite data
-	{ "232-c2cbt.bin",	0x800000, 0xb7bef674, 3 | BRF_GRA },           //  4
+	{ "232-c1cbt.c1",	0x800000, 0xea16b711, 3 | BRF_GRA },           //  3 Sprite data
+	{ "232-c2cbt.c2",	0x800000, 0xb7bef674, 3 | BRF_GRA },           //  4
 	{ "232-c3.c3",		0x800000, 0x581d6618, 3 | BRF_GRA },           //  5
 	{ "232-c4.c4",		0x800000, 0x49bb1e68, 3 | BRF_GRA },           //  6
-	{ "232-c5cbt.bin",	0x400000, 0x6fe02054, 3 | BRF_GRA },           //  7
-	{ "232-c6cbt.bin",	0x400000, 0x0f96c84a, 3 | BRF_GRA },           //  8
+	{ "232-c5cbt.c5",	0x400000, 0x6fe02054, 3 | BRF_GRA },           //  7
+	{ "232-c6cbt.c6",	0x400000, 0x0f96c84a, 3 | BRF_GRA },           //  8
 
 	{ "232-m1.m1",		0x020000, 0x45348747, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
 
@@ -19636,7 +19620,7 @@ static struct BurnRomInfo kof97cbtRomDesc[] = {
 STDROMPICKEXT(kof97cbt, kof97cbt, neogeo)
 STD_ROM_FN(kof97cbt)
 
-struct BurnDriver BurnDrvkof97cbt = {
+struct BurnDriver BurnDrvKof97cbt = {
 	"kof97cbt", "kof97", "neogeo", NULL, "2019",
 	"The King of Fighters '97 - Combo Training (Hack, Ver. 2018)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19675,7 +19659,7 @@ static struct BurnRomInfo kof97invplusRomDesc[] = {
 STDROMPICKEXT(kof97invplus, kof97invplus, neogeo)
 STD_ROM_FN(kof97invplus)
 
-struct BurnDriver BurnDrvkof97invplus = {
+struct BurnDriver BurnDrvKof97invplus = {
 	"kof97inv", "kof97", "neogeo", NULL, "2019",
 	"The King of Fighters '97 (Invincible Plus)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19687,7 +19671,7 @@ struct BurnDriver BurnDrvkof97invplus = {
 
 // The King of Fighters 2002 - 3rd Strike of Orochi (Hack by EGCG/EGHT)
 static struct BurnRomInfo kf2k23rdRomDesc[] = {
-	{ "265-p13rd.p1",	0x100000, 0xeb84d68f, 1 | BRF_ESS | BRF_PRG }, // 0 68K code
+	{ "265-p13rdo.p1",	0x100000, 0xeb84d68f, 1 | BRF_ESS | BRF_PRG }, // 0 68K code
 	{ "265-p23rdg.sp2",	0x400000, 0x293bbf78, 1 | BRF_ESS | BRF_PRG }, // 1
 
 	{ "265-s13rd.s1",	0x020000, 0x67e7cbe1, 2 | BRF_GRA },           // 2 Text layer tiles
@@ -19699,7 +19683,7 @@ static struct BurnRomInfo kf2k23rdRomDesc[] = {
 	{ "265-c5d.c5",		0x800000, 0x74bba7c6, 3 | BRF_GRA },           // 7
 	{ "265-c6d.c6",		0x800000, 0xe20d2216, 3 | BRF_GRA },           // 8
 	{ "265-c73rd.c7",	0x800000, 0x201e75e0, 3 | BRF_GRA },           // 9
-	{ "265-c83rd.c6",	0x800000, 0xff0fd53b, 3 | BRF_GRA },           // 10
+	{ "265-c83rd.c8",	0x800000, 0xff0fd53b, 3 | BRF_GRA },           // 10
 
 	{ "265-m1d.m1",		0x020000, 0x1c661a4b, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
@@ -19710,7 +19694,7 @@ static struct BurnRomInfo kf2k23rdRomDesc[] = {
 STDROMPICKEXT(kf2k23rd, kf2k23rd, neogeo)
 STD_ROM_FN(kf2k23rd)
 
-struct BurnDriver BurnDrvkf2k23rd = {
+struct BurnDriver BurnDrvKf2k23rd = {
 	"kf2k23rd", "kof2002", "neogeo", NULL, "200?",
 	"The King of Fighters 2002 - 3rd Strike of Orochi (Hack by EGCG/EGHT)\0", NULL, "hack", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
@@ -19748,7 +19732,7 @@ static struct BurnRomInfo kof99rp2fRomDesc[] = {
 STDROMPICKEXT(kof99rp2f, kof99rp2f, neogeo)
 STD_ROM_FN(kof99rp2f)
 
-struct BurnDriver BurnDrvkof99rp2f = {
+struct BurnDriver BurnDrvKof99rp2f = {
 	"kof99rp2f", "kof99", "neogeo", NULL, "2006",
 	"The King of Fighters '99 Remix Pro V2.0 Final (Hack By FCHT)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19794,7 +19778,7 @@ static INT32 Kof99TimePatchInit() // We need this patch to get timer working pro
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof99eur = {
+struct BurnDriver BurnDrvKof99eur = {
 	"kof99eur", "kof99", "neogeo", NULL, "201?",
 	"The King of Fighters '99 Evolution Ultra Remix (Hack By Yashional)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19832,7 +19816,7 @@ static struct BurnRomInfo kof99srRomDesc[] = {
 STDROMPICKEXT(kof99sr, kof99sr, neogeo)
 STD_ROM_FN(kof99sr)
 
-struct BurnDriver BurnDrvkof99sr = {
+struct BurnDriver BurnDrvKof99sr = {
 	"kof99sr", "kof99", "neogeo", NULL, "200?",
 	"The King of Fighters '99 Summer Revolution (Hack By FCHT)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19867,7 +19851,7 @@ static struct BurnRomInfo kf2k3ps2RomDesc[] = {
 STDROMPICKEXT(kf2k3ps2, kf2k3ps2, neogeo)
 STD_ROM_FN(kf2k3ps2)
 
-struct BurnDriver BurnDrvkf2k3ps2 = {
+struct BurnDriver BurnDrvKf2k3ps2 = {
 	"kf2k3ps2", "kof2003", "neogeo", NULL, "2006",
 	"The King of Fighters 2003 PlayStation 2 (Hack By EGCG)\0", "Use AES (Console) mode!", "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19906,7 +19890,7 @@ static struct BurnRomInfo kof98eckvsRomDesc[] = {
 STDROMPICKEXT(kof98eckvs, kof98eckvs, neogeo)
 STD_ROM_FN(kof98eckvs)
 
-struct BurnDriver BurnDrvkof98eckvs = {
+struct BurnDriver BurnDrvKof98eckvs = {
 	"kof98eckvs", "kof98", "neogeo", NULL, "2019",
 	"The King of Fighters '98 Easy Combo King 2014 (Versus Version, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -19925,12 +19909,12 @@ static struct BurnRomInfo kof10thuoRomDesc[] = {
 
 	{ "kf10-c1uo.bin",	0x800000, 0x2491af91, 3 | BRF_GRA },           //  2 Sprite data
 	{ "kf10-c2uo.bin",	0x800000, 0x47ff1d91, 3 | BRF_GRA },           //  3
-	{ "kf10-c3d.bin",	0x800000, 0x959fad0b, 3 | BRF_GRA },           //  4
-	{ "kf10-c4d.bin",	0x800000, 0xefe6a468, 3 | BRF_GRA },           //  5
-	{ "kf10-c5d.bin",	0x800000, 0x74bba7c6, 3 | BRF_GRA },           //  6
-	{ "kf10-c6d.bin",	0x800000, 0xe20d2216, 3 | BRF_GRA },           //  7
-	{ "kf10-c7d.bin",	0x800000, 0x8a5b561c, 3 | BRF_GRA },           //  8
-	{ "kf10-c8d.bin",	0x800000, 0xbef667a3, 3 | BRF_GRA },           //  9
+	{ "kf10-c3.bin",	0x800000, 0x959fad0b, 3 | BRF_GRA },           //  4
+	{ "kf10-c4.bin",	0x800000, 0xefe6a468, 3 | BRF_GRA },           //  5
+	{ "kf10-c5.bin",	0x800000, 0x74bba7c6, 3 | BRF_GRA },           //  6
+	{ "kf10-c6.bin",	0x800000, 0xe20d2216, 3 | BRF_GRA },           //  7
+	{ "kf10-c7.bin",	0x800000, 0x8a5b561c, 3 | BRF_GRA },           //  8
+	{ "kf10-c8.bin",	0x800000, 0xbef667a3, 3 | BRF_GRA },           //  9
 
 	{ "kf10-m1.bin",	0x020000, 0xf6fab859, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code
 
@@ -19942,7 +19926,7 @@ static struct BurnRomInfo kof10thuoRomDesc[] = {
 STDROMPICKEXT(kof10thuo, kof10thuo, neogeo)
 STD_ROM_FN(kof10thuo)
 
-struct BurnDriver BurnDrvkof10thuo = {
+struct BurnDriver BurnDrvKof10thuo = {
 	"kof10thuo", "kof2002", "neogeo", NULL, "2019",
 	"The King of Fighters 10th Anniversary 2019 (Optimized, Hack)\0", NULL, "hack", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
@@ -19978,7 +19962,7 @@ static struct BurnRomInfo kf2k2ru35RomDesc[] = {
 STDROMPICKEXT(kf2k2ru35, kf2k2ru35, neogeo)
 STD_ROM_FN(kf2k2ru35)
 
-struct BurnDriver BurnDrvkf2k2ru35 = {
+struct BurnDriver BurnDrvKf2k2ru35 = {
 	"kf2k2ru35", "kof2002", "neogeo", NULL, "2006",
 	"The King of Fighters 2002 Remix Ultra 3.5 (Hack By FCHT)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20012,7 +19996,7 @@ static struct BurnRomInfo kof2002scRomDesc[] = {
 STDROMPICKEXT(kof2002sc, kof2002sc, neogeo)
 STD_ROM_FN(kof2002sc)
 
-struct BurnDriver BurnDrvkof2002sc = {
+struct BurnDriver BurnDrvKof2002sc = {
 	"kof2002sc", "kof2002", "neogeo", NULL, "201?",
 	"The King of Fighters 2002 Same Character (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20053,7 +20037,7 @@ static struct BurnRomInfo kof2002mRomDesc[] = {
 STDROMPICKEXT(kof2002m, kof2002m, neogeo)
 STD_ROM_FN(kof2002m)
 
-struct BurnDriver BurnDrvkof2002m = {
+struct BurnDriver BurnDrvKof2002m = {
 	"kof2002m", "kof2002", "neogeo", NULL, "2023",
 	"The King of Fighters 2002 Mugen (Version 0.26, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20084,7 +20068,7 @@ static struct BurnRomInfo sdodgebhRomDesc[] = {
 STDROMPICKEXT(sdodgebh, sdodgebh, neogeo)
 STD_ROM_FN(sdodgebh)
 
-struct BurnDriver BurnDrvsdodgebh = {
+struct BurnDriver BurnDrvSdodgebh = {
 	"sdodgebh", "sdodgeb", "neogeo", NULL, "1996",
 	"Super Dodge Ball / Kunio no Nekketsu Toukyuu Densetsu (Secret Character Hack)\0", NULL, "Technos", "Neo Geo MVS",
 	L"Super Dodge Ball\0\u304F\u306B\u304A\u306E\u71B1\u8840\u95D8\u7403\u4F1D\u8AAC (Secret Character Hack)\0", NULL, NULL, NULL,
@@ -20115,7 +20099,7 @@ static struct BurnRomInfo magdrop3bhRomDesc[] = {
 STDROMPICKEXT(magdrop3bh, magdrop3bh, neogeo)
 STD_ROM_FN(magdrop3bh)
 
-struct BurnDriver BurnDrvmagdrop3bh = {
+struct BurnDriver BurnDrvMagdrop3bh = {
 	"magdrop3bh", "magdrop3", "neogeo", NULL, "1997",
 	"Magical Drop III (Secret Character Hack)\0", NULL, "Data East Corporation", "Neo Geo MVS",
 	L"Magical Drop III\0\u30DE\u30B8\u30AB\u30EB\u30C9\u30ED\u30C3\u30D7III (Secret Character Hack)\0", NULL, NULL, NULL,
@@ -20149,7 +20133,7 @@ static struct BurnRomInfo wakuwak7bhRomDesc[] = {
 STDROMPICKEXT(wakuwak7bh, wakuwak7bh, neogeo)
 STD_ROM_FN(wakuwak7bh)
 
-struct BurnDriver BurnDrvwakuwak7bh = {
+struct BurnDriver BurnDrvWakuwak7bh = {
 	"wakuwak7bh", "wakuwak7", "neogeo", NULL, "1996",
 	"Waku Waku 7 (Boss Hack)\0", NULL, "hack", "Neo Geo MVS",
 	L"Waku Waku 7\0\u308F\u304F\u308F\u304F\uFF17 (Boss Hack)\0", NULL, NULL, NULL,
@@ -20185,7 +20169,7 @@ static struct BurnRomInfo rbff2bhRomDesc[] = {
 STDROMPICKEXT(rbff2bh, rbff2bh, neogeo)
 STD_ROM_FN(rbff2bh)
 
-struct BurnDriver BurnDrvrbff2bh = {
+struct BurnDriver BurnDrvRbff2bh = {
 	"rbff2bh", "rbff2", "neogeo", NULL, "1998",
 	"Real Bout Fatal Fury 2 - The Newcomers / Real Bout Garou Densetsu 2 - the newcomers (Secret Character Hack) (NGM-2400)\0", NULL, "SNK", "Neo Geo MVS",
 	L"Real Bout Fatal Fury 2 - The Newcomers\0Real Bout \u9913\u72FC\u4F1D\u8AAC\uFF12 (Secret Character Hack) (NGM-2400)\0", NULL, NULL, NULL,
@@ -20222,7 +20206,7 @@ static struct BurnRomInfo rbffspbhRomDesc[] = {
 STDROMPICKEXT(rbffspbh, rbffspbh, neogeo)
 STD_ROM_FN(rbffspbh)
 
-struct BurnDriver BurnDrvrbffspbh = {
+struct BurnDriver BurnDrvRbffspbh = {
 	"rbffspbh", "rbffspec", "neogeo", NULL, "1996",
 	"Real Bout Fatal Fury Special / Real Bout Garou Densetsu Special (Boss Hack)\0", NULL, "SNK", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20232,12 +20216,12 @@ struct BurnDriver BurnDrvrbffspbh = {
 	0x1000, 320, 224, 4, 3
 };
 
-// Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer (Eternal, Hack) - 2024-05-23
+// Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer (Eternal, Hack) - 2025-04-19
 // Modified by jlima
-// https://www.ppxclub.com/forum.php?mod=viewthread&tid=724160
+// https://bbs.xqemu.cn/forum.php?mod=viewthread&tid=3870
 
 static struct BurnRomInfo gowcaietRomDesc[] = {
-	{ "094-p1et.p1",	0x200000, 0x4236d373, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "094-p1et.p1",	0x200000, 0xb48292ff, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "094-s1.s1",		0x020000, 0x2f8748a2, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -20261,8 +20245,8 @@ STDROMPICKEXT(gowcaiet, gowcaiet, neogeo)
 STD_ROM_FN(gowcaiet)
 
 struct BurnDriver BurnDrvGowcaiet = {
-	"gowcaiet", "gowcaizr", "neogeo", NULL, "2024",
-	"Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer (Eternal, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"gowcaiet", "gowcaizr", "neogeo", NULL, "2025",
+	"Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer (Eternal, Hack)\0", NULL, "hack (jLima)", "Neo Geo MVS",
 	L"Voltage Fighter - Gowcaizer\0\u8D85\u4EBA\u5B66\u5712\u30B4\u30A6\u30AB\u30A4\u30B6\u30FC (Eternal, Hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, 0,
 	NULL, gowcaietRomInfo, gowcaietRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
@@ -20276,7 +20260,7 @@ struct BurnDriver BurnDrvGowcaiet = {
 
 static struct BurnRomInfo teotRomDesc[] = {
 	{ "teot-p1.bin",    0x0100000, 0xc0ae0a56, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "teot-p2.bin",    0x0800000, 0x68dc7463, 1 | BRF_ESS | BRF_PRG }, //  1 68K code
+	{ "teot-p2.bin",    0x0800000, 0x68dc7463, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "teot-s1.bin",    0x0020000, 0x6d05f74b, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -20294,7 +20278,7 @@ STD_ROM_FN(teot)
 
 struct BurnDriver BurnDrvTeot = {
 	"teot", NULL, "neogeo", NULL, "2022",
-	"The Eye of Typhoon (Beta 7 Version)\0", NULL, "OzzyOuzo", "Neo Geo MVS",
+	"The Eye of Typhoon (HB, Beta 7 Version)\0", NULL, "OzzyOuzo", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, 0,
 	NULL, teotRomInfo, teotRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
@@ -20302,7 +20286,44 @@ struct BurnDriver BurnDrvTeot = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Cyborg Force
+// ----------
+// Extra Roms
+// ----------
+
+// Block Panic DX (HB, ver. 2025/01/01)
+// https://www.patreon.com/posts/block-panic-dx-119035418
+// 3 & 4 players not working (needs Multitap)
+
+static struct BurnRomInfo bpanicdxRomDesc[] = {
+	{ "bpanicdx.p1",	0x80000, 0x8f59134f, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+
+	{ "bpanicdx.s1",	0x20000, 0x387a8f43, 2 | BRF_GRA },           //  1 Text layer tiles
+
+	{ "bpanicdx.c1",	0x80000, 0x9463af81, 3 | BRF_GRA },           //  2 Sprite data
+	{ "bpanicdx.c2",	0x80000, 0xa290a403, 3 | BRF_GRA },           //  3
+
+	{ "bpanicdx.m1",	0x20000, 0xd74159c0, 4 | BRF_ESS | BRF_PRG }, //  4 Z80 code
+
+	{ "bpanicdx.v1",	0x80000, 0x55185687, 5 | BRF_SND },           //  5 Sound data
+	{ "bpanicdx.v2",	0x80000, 0x7211595d, 5 | BRF_SND },           //  6
+	{ "bpanicdx.v3",	0x80000, 0xe08afa9f, 5 | BRF_SND },           //  7
+	{ "bpanicdx.v4",	0x80000, 0x5a9d8d69, 5 | BRF_SND },           //  8
+};
+
+STDROMPICKEXT(bpanicdx, bpanicdx, neogeo)
+STD_ROM_FN(bpanicdx)
+
+struct BurnDriver BurnDrvBpanicdx = {
+	"bpanicdx", NULL, "neogeo", NULL, "2025",
+	"Block Panic DX (HB, ver. 2025/01/01)\0", NULL, "Blastar", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_PUZZLE, 0,
+	NULL, bpanicdxRomInfo, bpanicdxRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+// Cyborg Force (HB)
 // NEO.BYTE.FORCE
 // 20230409
 // https://www.neobyteforce.com/
@@ -20319,7 +20340,7 @@ static struct BurnRomInfo cyborgforceRomDesc[] = {
 	{ "cyborg-m1.bin",	0x0010000, 0x06da3cec, 4 | BRF_ESS | BRF_PRG }, 	//  5 Z80 code
 
 	{ "cyborg-v1.bin",	0x0800000, 0xdc50718c, 5 | BRF_SND },           	//  6 Sound data
-	{ "cyborg-v2.bin",	0x0800000, 0x8135d5a8, 5 | BRF_SND },           	//  6 Sound data
+	{ "cyborg-v2.bin",	0x0800000, 0x8135d5a8, 5 | BRF_SND },           	//  7
 };
 
 STDROMPICKEXT(cyborgforce, cyborgforce, neogeo)
@@ -20327,10 +20348,40 @@ STD_ROM_FN(cyborgforce)
 
 struct BurnDriver BurnDrvCyborgForce = {
 	"cyborgforce", NULL, "neogeo", NULL, "2023",
-	"Cyborg Force!\0", NULL, "NEO.BYTE.FORCE", "Neo Geo MVS",
+	"Cyborg Force (HB)\0", NULL, "Neo Byte Force", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN | GBF_SHOOT, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN | GBF_PLATFORM, 0,
 	NULL, cyborgforceRomInfo, cyborgforceRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 320, 224, 4, 3
+};
+
+// Flappy Chicken (HB, ver. 2023/04/30)
+// https://blastar.citavia.de/
+
+static struct BurnRomInfo flapchckRomDesc[] = {
+	{ "flapchck.p1",	0x80000, 0x2a7454a1, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+
+	{ "flapchck.s1",	0x20000, 0x3fd2b4d4, 2 | BRF_GRA },           //  1 Text layer tiles
+
+	{ "flapchck.c1",	0x80000, 0x4ecdb8ca, 3 | BRF_GRA },           //  2 Sprite data
+	{ "flapchck.c2",	0x80000, 0x47d06927, 3 | BRF_GRA },           //  3
+
+	{ "flapchck.m1",	0x20000, 0x5abc1bf6, 4 | BRF_ESS | BRF_PRG }, //  4 Z80 code
+
+	{ "flapchck.v1",	0x80000, 0xc5d09e58, 5 | BRF_SND },           //  5 Sound data
+	{ "flapchck.v2",	0x80000, 0xb9afe241, 5 | BRF_SND },           //  6
+};
+
+STDROMPICKEXT(flapchck, flapchck, neogeo)
+STD_ROM_FN(flapchck)
+
+struct BurnDriver BurnDrvFlapchck = {
+	"flapchck", NULL, "neogeo", NULL, "2023",
+	"Flappy Chicken (HB, ver. 2023/04/30)\0", NULL, "Blastar", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_PLATFORM, 0,
+	NULL, flapchckRomInfo, flapchckRomName, NULL, NULL, NULL, NULL, neodualInputInfo, neodualDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 320, 224, 4, 3
 };
@@ -20359,16 +20410,43 @@ STD_ROM_FN(yoyoshkn)
 struct BurnDriver BurnDrvYoyoshkn = {
 	"yoyoshkn", NULL, "neogeo", NULL, "2023",
 	"Yo-Yo Shuriken (HB)\0", NULL, "LudoSience", "Neo Geo MVS",
-	L"\u30e8\u30fc\u30e8\u30fc\u624b\u88cf\u5263\0YoYo-Shuriken (HB)\0", NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_SHOOT, 0,
+	L"\u30e8\u30fc\u30e8\u30fc\u624b\u88cf\u5263\0Yo-Yo Shuriken (HB)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, 0,
 	NULL, yoyoshknRomInfo, yoyoshknRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 
-// ----------
-// Extra Roms
-// ----------
+// Xeno Crisis (HB)
+/* MVS AND AES VERSION */
+
+static struct BurnRomInfo xenocrisisRomDesc[] = {
+	{ "BB01-p1.p1",		0x0100000, 0x637605a6, 1 | BRF_ESS | BRF_PRG }, 	//  0 68K code
+	{ "BB01-p2.p2",		0x0100000, 0x84838145, 1 | BRF_ESS | BRF_PRG }, 	//  1
+
+	{ "BB01-s1.s1",		0x0020000, 0x7537ea79, 2 | BRF_GRA },           	//  2 Text layer tiles
+
+	{ "BB01-c1.c1",		0x0200000, 0xae51ef89, 3 | BRF_GRA },           	//  3 Sprite data
+	{ "BB01-c2.c2",		0x0200000, 0xa8610100, 3 | BRF_GRA },           	//  4
+
+	{ "BB01-m1.m1",		0x0010000, 0x28c13ed9, 4 | BRF_ESS | BRF_PRG }, 	//  5 Z80 code
+
+	{ "BB01-v1.v1",		0x1000000, 0x60d57867, 5 | BRF_SND },           	//  6 Sound data
+};
+
+STDROMPICKEXT(xenocrisis, xenocrisis, neogeo)
+STD_ROM_FN(xenocrisis)
+
+struct BurnDriver BurnDrvXenocrisis = {
+	"xenocrisis", NULL, "neogeo", NULL, "2019",
+	"Xeno Crisis (HB)\0", "NGM-BB01 ~ NGH-BB01", "Bitmap Bureau", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, 0,
+	NULL, xenocrisisRomInfo, xenocrisisRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 320, 224, 4, 3
+};
+
 
 // Metal Slug Unity (Added Timer)
 // Modified by Alice愛麗絲/合金弹头爱克斯/CXZInc
@@ -20392,7 +20470,7 @@ static struct BurnRomInfo mslugunityRomDesc[] = {
 STDROMPICKEXT(mslugunity, mslugunity, neogeo)
 STD_ROM_FN(mslugunity)
 
-struct BurnDriver BurnDrvmslugunity = {
+struct BurnDriver BurnDrvMslugunity = {
 	"mslugunity", "mslug", "neogeo", NULL, "2021",
 	"Metal Slug Unity (Added Timer)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20426,7 +20504,7 @@ static struct BurnRomInfo mslug2unityRomDesc[] = {
 STDROMPICKEXT(mslug2unity, mslug2unity, neogeo)
 STD_ROM_FN(mslug2unity)
 
-struct BurnDriver BurnDrvmslug2unity = {
+struct BurnDriver BurnDrvMslug2unity = {
 	"mslug2unity", "mslug2", "neogeo", NULL, "2021",
 	"Metal Slug 2 Unity (Added Timer)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20462,7 +20540,7 @@ static struct BurnRomInfo mslugxunityRomDesc[] = {
 STDROMPICKEXT(mslugxunity, mslugxunity, neogeo)
 STD_ROM_FN(mslugxunity)
 
-struct BurnDriver BurnDrvmslugxunity = {
+struct BurnDriver BurnDrvMslugxunity = {
 	"mslugxunity", "mslugx", "neogeo", NULL, "2021",
 	"Metal Slug X Unity (Added Timer)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20503,7 +20581,7 @@ static struct BurnRomInfo mslug3unityRomDesc[] = {
 STDROMPICKEXT(mslug3unity, mslug3unity, neogeo)
 STD_ROM_FN(mslug3unity)
 
-struct BurnDriver BurnDrvmslug3unity = {
+struct BurnDriver BurnDrvMslug3unity = {
 	"mslug3unity", "mslug3", "neogeo", NULL, "2021",
 	"Metal Slug 3 Unity (Added Timer)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20540,7 +20618,7 @@ static struct BurnRomInfo mslug4unityRomDesc[] = {
 STDROMPICKEXT(mslug4unity, mslug4unity, neogeo)
 STD_ROM_FN(mslug4unity)
 
-struct BurnDriver BurnDrvmslug4unity = {
+struct BurnDriver BurnDrvMslug4unity = {
 	"mslug4unity", "mslug4", "neogeo", NULL, "2021",
 	"Metal Slug 4 Unity (Added Timer)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20579,7 +20657,7 @@ static struct BurnRomInfo mslug5unityRomDesc[] = {
 STDROMPICKEXT(mslug5unity, mslug5unity, neogeo)
 STD_ROM_FN(mslug5unity)
 
-struct BurnDriver BurnDrvmslug5unity = {
+struct BurnDriver BurnDrvMslug5unity = {
 	"mslug5unity", "mslug5", "neogeo", NULL, "2021",
 	"Metal Slug 5 Unity (Added Timer)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20662,7 +20740,7 @@ static struct BurnRomInfo kof2k1rpRomDesc[] = {
 STDROMPICKEXT(kof2k1rp, kof2k1rp, neogeo)
 STD_ROM_FN(kof2k1rp)
 
-struct BurnDriver BurnDrvkof2k1rp = {
+struct BurnDriver BurnDrvKof2k1rp = {
 	"kof2k1rp", "kof2001", "neogeo", NULL, "Version 2004-03-01",
 	"The King of Fighters 2001 Remix Pro v1.02 Final (Hack By Jason, Kim & Raymonose)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20700,7 +20778,7 @@ static struct BurnRomInfo kof2000bcRomDesc[] = {
 STDROMPICKEXT(kof2000bc, kof2000bc, neogeo)
 STD_ROM_FN(kof2000bc)
 
-struct BurnDriver BurnDrvkof2000bc = {
+struct BurnDriver BurnDrvKof2000bc = {
 	"kof2000bc", "kof2000", "neogeo", NULL, "2021",
 	"The King of Fighters 2000 Special BC (Hack By GSC2007, EGCG, AILLIS)\0", "Press AD for Start BC Mode", "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20740,7 +20818,7 @@ static struct BurnRomInfo kof2kxxxRomDesc[] = {
 STDROMPICKEXT(kof2kxxx, kof2kxxx, neogeo)
 STD_ROM_FN(kof2kxxx)
 
-struct BurnDriver BurnDrvkof2kxxx = {
+struct BurnDriver BurnDrvKof2kxxx = {
 	"kof2kxxx", "kof2000", "neogeo", NULL, "2016",
 	"The King of Fighters 2000 SP XXX (Hack, Ver. 2016-01-04)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20776,7 +20854,7 @@ static struct BurnRomInfo kf2k3ps2spRomDesc[] = {
 STDROMPICKEXT(kf2k3ps2sp, kf2k3ps2sp, neogeo)
 STD_ROM_FN(kf2k3ps2sp)
 
-struct BurnDriver BurnDrvkf2k3ps2sp = {
+struct BurnDriver BurnDrvKf2k3ps2sp = {
 	"kf2k3ps2sp", "kof2003", "neogeo", NULL, "20??",
 	"The King of Fighters 2003 - PS2 Style Portraits (Hack By 0 Day-S, Eddids, Hiker)\0", "Secret Characters available in MVS", "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20872,12 +20950,12 @@ struct BurnDriver BurnDrvKof94tea = {
 
 static struct BurnRomInfo kof97bngRomDesc[] = {
 	{ "232-p1bng.p1",	0x100000, 0x5357e1b0, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
-	{ "232-p2bng.p2",	0x400000, 0xd86d0095, 1 | BRF_ESS | BRF_PRG },	//  1
+	{ "232-p2bng.sp2",	0x400000, 0xd86d0095, 1 | BRF_ESS | BRF_PRG },	//  1
 
 	{ "232-s1bng.s1",	0x020000, 0xc24e2cb7, 2 | BRF_GRA },			//  2 Text layer tiles
 
-	{ "232-c1bng.c1",	0x800000, 0xd504bf4a, 3 | BRF_GRA },			//  3 Sprite data
-	{ "232-c2bng.c2",	0x800000, 0x942ea708, 3 | BRF_GRA },			//  4
+	{ "232-c1xt.c1",	0x800000, 0xd504bf4a, 3 | BRF_GRA },			//  3 Sprite data
+	{ "232-c2xt.c2",	0x800000, 0x942ea708, 3 | BRF_GRA },			//  4
 	{ "232-c3.c3",		0x800000, 0x581d6618, 3 | BRF_GRA },			//  5
 	{ "232-c4.c4",		0x800000, 0x49bb1e68, 3 | BRF_GRA },			//  6
 	{ "232-c5bng.c5",	0x400000, 0xe749d4d2, 3 | BRF_GRA },			//  7
@@ -20893,12 +20971,48 @@ static struct BurnRomInfo kof97bngRomDesc[] = {
 STDROMPICKEXT(kof97bng, kof97bng, neogeo)
 STD_ROM_FN(kof97bng)
 
-struct BurnDriver BurnDrvkof97bng = {
+struct BurnDriver BurnDrvKof97bng = {
 	"kof97bng", "kof97", "neogeo", NULL, "20??",
 	"The King of Fighters '97 Bing Edition (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof97bngRomInfo, kof97bngRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+// The King of Fighters '97 (Balanced & Optimized, Hack)
+// GOTVG 20231225
+
+static struct BurnRomInfo kof97btRomDesc[] = {
+	{ "232-p1bt.p1",	0x100000, 0xefd8fa38, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "232-p2bt.sp2",	0x400000, 0x6ab81bd7, 1 | BRF_ESS | BRF_PRG }, //  1 
+
+	{ "232-s1.s1",		0x020000, 0x8514ecf5, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "232-c1bt.c1",	0x800000, 0x1a5bfb12, 3 | BRF_GRA },           //  3 Sprite data
+	{ "232-c2bt.c2",	0x800000, 0xa405f128, 3 | BRF_GRA },           //  4 
+	{ "232-c3.c3",		0x800000, 0x581d6618, 3 | BRF_GRA },           //  5 
+	{ "232-c4.c4",		0x800000, 0x49bb1e68, 3 | BRF_GRA },           //  6 
+	{ "232-c5.c5",		0x400000, 0x34fc4e51, 3 | BRF_GRA },           //  7 
+	{ "232-c6.c6",		0x400000, 0x4ff4d47b, 3 | BRF_GRA },           //  8 
+
+	{ "232-m1.m1",		0x020000, 0x45348747, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+
+	{ "232-v1.v1",		0x400000, 0x22a2b5b5, 5 | BRF_SND },           // 10 Sound data
+	{ "232-v2.v2",		0x400000, 0x2304e744, 5 | BRF_SND },           // 11 
+	{ "232-v3.v3",		0x400000, 0x759eb954, 5 | BRF_SND },           // 12 
+};
+
+STDROMPICKEXT(kof97bt, kof97bt, neogeo)
+STD_ROM_FN(kof97bt)
+
+struct BurnDriver BurnDrvKof97bt = {
+	"kof97bt", "kof97", "neogeo", NULL, "2023",
+	"The King of Fighters '97 (Balanced & Optimized, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof97btRomInfo, kof97btRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -20930,7 +21044,7 @@ static struct BurnRomInfo kof97evnRomDesc[] = {
 STDROMPICKEXT(kof97evn, kof97evn, neogeo)
 STD_ROM_FN(kof97evn)
 
-struct BurnDriver BurnDrvkof97evn = {
+struct BurnDriver BurnDrvKof97evn = {
 	"kof97evn", "kof97", "neogeo", NULL, "200?",
 	"The King of Fighters '97 Evolution New (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -20943,7 +21057,7 @@ struct BurnDriver BurnDrvkof97evn = {
 // The King of Fighters '97 (Ratio v1.0, Hack)
 // https://romhackplaza.org/romhacks/king-of-fighters-97-arcade/
 
-static struct BurnRomInfo kof97rtoRomDesc[] = {
+static struct BurnRomInfo kof97ratioRomDesc[] = {
 	{ "232-p1rto.p1",	0x100000, 0xc7d6c2f0, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 	{ "232-p2.sp2",		0x400000, 0x158b23f6, 1 | BRF_ESS | BRF_PRG }, //  1 
 
@@ -20963,15 +21077,15 @@ static struct BurnRomInfo kof97rtoRomDesc[] = {
 	{ "232-v3.v3",		0x400000, 0x759eb954, 5 | BRF_SND },           // 12 
 };
 
-STDROMPICKEXT(kof97rto, kof97rto, neogeo)
-STD_ROM_FN(kof97rto)
+STDROMPICKEXT(kof97ratio, kof97ratio, neogeo)
+STD_ROM_FN(kof97ratio)
 
-struct BurnDriver BurnDrvKof97rto = {
-	"kof97rto", "kof97", "neogeo", NULL, "2023",
+struct BurnDriver BurnDrvKof97ratio = {
+	"kof97ratio", "kof97", "neogeo", NULL, "2023",
 	"The King of Fighters '97 (Ratio v1.0, Hack)\0", NULL, "hack (bankbank)", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
-	NULL, kof97rtoRomInfo, kof97rtoRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NULL, kof97ratioRomInfo, kof97ratioRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -21002,7 +21116,7 @@ static struct BurnRomInfo kof97spwRomDesc[] = {
 STDROMPICKEXT(kof97spw, kof97spw, neogeo)
 STD_ROM_FN(kof97spw)
 
-struct BurnDriver BurnDrvkof97spw = {
+struct BurnDriver BurnDrvKof97spw = {
 	"kof97spw", "kof97", "neogeo", NULL, "2023",
 	"The King of Fighters '97 Super Plus (Version 1.2, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21037,7 +21151,7 @@ static struct BurnRomInfo kof97ubpRomDesc[] = {
 STDROMPICKEXT(kof97ubp, kof97ubp, neogeo)
 STD_ROM_FN(kof97ubp)
 
-struct BurnDriver BurnDrvkof97ubp = {
+struct BurnDriver BurnDrvKof97ubp = {
 	"kof97ubp", "kof97", "neogeo", NULL, "2020",
 	"The King of Fighters '97 Ultimate Battle Plus (Build Ver.2021-09-20, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21063,8 +21177,8 @@ static struct BurnRomInfo kof97ulRomDesc[] = {
 	{ "232-c2ul.c2",	0x800000, 0x6660e94d, 3 | BRF_GRA },           //  4
 	{ "232-c3.c3",		0x800000, 0x581d6618, 3 | BRF_GRA },           //  5
 	{ "232-c4.c4",		0x800000, 0x49bb1e68, 3 | BRF_GRA },           //  6
-	{ "232-c5ul.c5",	0x400000, 0x6fe02054, 3 | BRF_GRA },           //  7
-	{ "232-c6ul.c6",	0x400000, 0x0f96c84a, 3 | BRF_GRA },           //  8
+	{ "232-c5cbt.c5",	0x400000, 0x6fe02054, 3 | BRF_GRA },           //  7
+	{ "232-c6cbt.c6",	0x400000, 0x0f96c84a, 3 | BRF_GRA },           //  8
 
 	{ "232-m1.m1",		0x020000, 0x45348747, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
 
@@ -21076,7 +21190,7 @@ static struct BurnRomInfo kof97ulRomDesc[] = {
 STDROMPICKEXT(kof97ul, kof97ul, neogeo)
 STD_ROM_FN(kof97ul)
 
-struct BurnDriver BurnDrvkof97ul = {
+struct BurnDriver BurnDrvKof97ul = {
 	"kof97ul", "kof97", "neogeo", NULL, "2023",
 	"The King of Fighters '97 Ultilimited (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21112,7 +21226,7 @@ static struct BurnRomInfo kof97ywbRomDesc[] = {
 STDROMPICKEXT(kof97ywb, kof97ywb, neogeo)
 STD_ROM_FN(kof97ywb)
 
-struct BurnDriver BurnDrvkof97ywb = {
+struct BurnDriver BurnDrvKof97ywb = {
 	"kof97ywb", "kof97", "neogeo", NULL, "2008",
 	"The King of Fighters '97 (Yukimura World Buwu)\0", NULL, "Hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21150,7 +21264,7 @@ static struct BurnRomInfo kof98bc2k2RomDesc[] = {
 STDROMPICKEXT(kof98bc2k2, kof98bc2k2, neogeo)
 STD_ROM_FN(kof98bc2k2)
 
-struct BurnDriver BurnDrvkof98bc2k2 = {
+struct BurnDriver BurnDrvKof98bc2k2 = {
 	"kof98bc2k2", "kof98", "neogeo", NULL, "20??",
 	"The King of Fighters '98 BC Style 2002 (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21205,7 +21319,7 @@ static INT32 kof98cpInit()
 	return nRet;
 }
 
-struct BurnDriver BurnDrvkof98cp = {
+struct BurnDriver BurnDrvKof98cp = {
 	"kof98cp", "kof98", "neogeo", NULL, "2020",
 	"The King of Fighters '98 (Combo Plus)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21244,7 +21358,7 @@ static struct BurnRomInfo kof98hcRomDesc[] = {
 STDROMPICKEXT(kof98hc, kof98hc, neogeo)
 STD_ROM_FN(kof98hc)
 
-struct BurnDriver BurnDrvkof98hc = {
+struct BurnDriver BurnDrvKof98hc = {
 	"kof98hc", "kof98", "neogeo", NULL, "20??",
 	"The King of Fighters '98 Heaven Cancel (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21282,7 +21396,7 @@ static struct BurnRomInfo kof98mpRomDesc[] = {
 STDROMPICKEXT(kof98mp, kof98mp, neogeo)
 STD_ROM_FN(kof98mp)
 
-struct BurnDriver BurnDrvkof98mp = {
+struct BurnDriver BurnDrvKof98mp = {
 	"kof98mp", "kof98", "neogeo", NULL, "20??",
 	"The King of Fighters '98 Metamorphosis Plus (Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21320,7 +21434,7 @@ static struct BurnRomInfo kof98scnRomDesc[] = {
 STDROMPICKEXT(kof98scn, kof98scn, neogeo)
 STD_ROM_FN(kof98scn)
 
-struct BurnDriver BurnDrvkof98scn = {
+struct BurnDriver BurnDrvKof98scn = {
 	"kof98scn", "kof98", "neogeo", NULL, "2020",
 	"The King of Fighters '98 Same Character (Neutrality, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21358,7 +21472,7 @@ static struct BurnRomInfo kof98evoRomDesc[] = {
 STDROMPICKEXT(kof98evo, kof98evo, neogeo)
 STD_ROM_FN(kof98evo)
 
-struct BurnDriver BurnDrvkof98evo = {
+struct BurnDriver BurnDrvKof98evo = {
 	"kof98evo", "kof98", "neogeo", NULL, "200?",
 	"The King of Fighters '98 Evolution (Hack By NEO Edit Team)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21397,7 +21511,7 @@ static struct BurnRomInfo kof99bcRomDesc[] = {
 STDROMPICKEXT(kof99bc, kof99bc, neogeo)
 STD_ROM_FN(kof99bc)
 
-struct BurnDriver BurnDrvkof99bc = {
+struct BurnDriver BurnDrvKof99bc = {
 	"kof99bc", "kof99", "neogeo", NULL, "2020",
 	"The King of Fighters '99 BC (AC open BC, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21436,7 +21550,7 @@ static struct BurnRomInfo kof99co2RomDesc[] = {
 STDROMPICKEXT(kof99co2, kof99co2, neogeo)
 STD_ROM_FN(kof99co2)
 
-struct BurnDriver BurnDrvkof99co2 = {
+struct BurnDriver BurnDrvKof99co2 = {
 	"kof99co2", "kof99", "neogeo", NULL, "2006",
 	"The King of Fighters '99 - Millennium Battle (Combo 2006, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21470,7 +21584,7 @@ static struct BurnRomInfo mslug1v2RomDesc[] = {
 STDROMPICKEXT(mslug1v2, mslug1v2, neogeo)
 STD_ROM_FN(mslug1v2)
 
-struct BurnDriver BurnDrvmslug1v2 = {
+struct BurnDriver BurnDrvMslug1v2 = {
 	"mslug1v2", "mslug", "neogeo", NULL, "2023",
 	"Metal Slug (1v2 Mode, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21480,11 +21594,11 @@ struct BurnDriver BurnDrvmslug1v2 = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug (Origins, Hack) - 2024-04-09
+// Metal Slug (Origins, Hack) - 2025-04-28
 // Modified by 合金弹头爱克斯 / CardCaptorSakura
 
 static struct BurnRomInfo mslugdqyRomDesc[] = {
-	{ "201-p1dqy.p1",	0x200000, 0x6313a19f, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "201-p1dqy.p1",	0x200000, 0xf50e465c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },           //  1 Text layer tiles
 
@@ -21502,8 +21616,8 @@ static struct BurnRomInfo mslugdqyRomDesc[] = {
 STDROMPICKEXT(mslugdqy, mslugdqy, neogeo)
 STD_ROM_FN(mslugdqy)
 
-struct BurnDriver BurnDrvmslugdqy = {
-	"mslugdqy", "mslug", "neogeo", NULL, "2024",
+struct BurnDriver BurnDrvMslugdqy = {
+	"mslugdqy", "mslug", "neogeo", NULL, "2025",
 	"Metal Slug (Origins, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_RUNGUN, FBF_MSLUG,
@@ -21533,7 +21647,7 @@ static struct BurnRomInfo mslugfc2RomDesc[] = {
 STDROMPICKEXT(mslugfc2, mslugfc2, neogeo)
 STD_ROM_FN(mslugfc2)
 
-struct BurnDriver BurnDrvmslugfc2 = {
+struct BurnDriver BurnDrvMslugfc2 = {
 	"mslugfc2", "mslug", "neogeo", NULL, "2024",
 	"Metal Slug (Random Item, Powerful Enemy Defense, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21564,7 +21678,7 @@ static struct BurnRomInfo mslugdyf1RomDesc[] = {
 STDROMPICKEXT(mslugdyf1, mslugdyf1, neogeo)
 STD_ROM_FN(mslugdyf1)
 
-struct BurnDriver BurnDrvmslugdyf1 = {
+struct BurnDriver BurnDrvMslugdyf1 = {
 	"mslugdyf1", "mslug", "neogeo", NULL, "2024",
 	"Metal Slug (Origins Random Item, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21598,7 +21712,7 @@ static struct BurnRomInfo mslug2pRomDesc[] = {
 STDROMPICKEXT(mslug2p, mslug2p, neogeo)
 STD_ROM_FN(mslug2p)
 
-struct BurnDriver BurnDrvMSlug2p = {
+struct BurnDriver BurnDrvMslug2p = {
 	"mslug2p", "mslug2", "neogeo", NULL, "2015",
 	"Metal Slug 2 (Weapon Storage, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21666,7 +21780,7 @@ static struct BurnRomInfo mslug2egRomDesc[] = {
 STDROMPICKEXT(mslug2eg, mslug2eg, neogeo)
 STD_ROM_FN(mslug2eg)
 
-struct BurnDriver BurnDrvMSlug2eg = {
+struct BurnDriver BurnDrvMslug2eg = {
 	"mslug2eg", "mslug2", "neogeo", NULL, "2021",
 	"Metal Slug 2 (Extraction Extreme Blue Turbo, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21703,7 +21817,7 @@ static struct BurnRomInfo mslugxc1RomDesc[] = {
 STDROMPICKEXT(mslugxc1, mslugxc1, neogeo)
 STD_ROM_FN(mslugxc1)
 
-struct BurnDriver BurnDrvMSlugXc1 = {
+struct BurnDriver BurnDrvMslugxc1 = {
 	"mslugxc1", "mslugx", "neogeo", NULL, "2013",
 	"Metal Slug X (Multi Vehicle, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21739,7 +21853,7 @@ static struct BurnRomInfo mslugx1v2RomDesc[] = {
 STDROMPICKEXT(mslugx1v2, mslugx1v2, neogeo)
 STD_ROM_FN(mslugx1v2)
 
-struct BurnDriver BurnDrvMSlugX1v2 = {
+struct BurnDriver BurnDrvMslugx1v2 = {
 	"mslugx1v2", "mslugx", "neogeo", NULL, "2019",
 	"Metal Slug X (1v2 Mode, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21775,7 +21889,7 @@ static struct BurnRomInfo mslugx2rRomDesc[] = {
 STDROMPICKEXT(mslugx2r, mslugx2r, neogeo)
 STD_ROM_FN(mslugx2r)
 
-struct BurnDriver BurnDrvMSlugX2r = {
+struct BurnDriver BurnDrvMslugx2r = {
 	"mslugx2r", "mslugx", "neogeo", NULL, "2020",
 	"Metal Slug X (2R, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21811,7 +21925,7 @@ static struct BurnRomInfo mslugx2rebRomDesc[] = {
 STDROMPICKEXT(mslugx2reb, mslugx2reb, neogeo)
 STD_ROM_FN(mslugx2reb)
 
-struct BurnDriver BurnDrvMSlugX2reb = {
+struct BurnDriver BurnDrvMslugx2reb = {
 	"mslugx2reb", "mslugx", "neogeo", NULL, "2020",
 	"Metal Slug X (2R Extreme Blue, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21847,7 +21961,7 @@ static struct BurnRomInfo mslugx2r1v2RomDesc[] = {
 STDROMPICKEXT(mslugx2r1v2, mslugx2r1v2, neogeo)
 STD_ROM_FN(mslugx2r1v2)
 
-struct BurnDriver BurnDrvMSlugX2r1v2 = {
+struct BurnDriver BurnDrvMslugx2r1v2 = {
 	"mslugx2r1v2", "mslugx", "neogeo", NULL, "2020",
 	"Metal Slug X (2R 1v2 Mode, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21857,12 +21971,12 @@ struct BurnDriver BurnDrvMSlugX2r1v2 = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary, Hack) - 2024-06-13
+// Metal Slug X (Legendary, Hack) - 2024-12-02
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslugxscRomDesc[] = {
-	{ "250-p1sc.p1",    0x100000, 0x6bbe0a36, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2sc.ep1",   0x400000, 0x3a368748, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1sc.p1",    0x100000, 0xbea434ac, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2sc.ep1",   0x400000, 0x80cd6b69, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",    0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -21894,7 +22008,7 @@ static INT32 mslugxscInit() // 400% speed, AliceMSU recomendation for mslugxsc
 	return nRet;
 }
 
-struct BurnDriver BurnDrvmslugxsc = {
+struct BurnDriver BurnDrvMslugxsc = {
 	"mslugxsc", "mslugx", "neogeo", NULL, "2024",
 	"Metal Slug X (Legendary, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21930,7 +22044,7 @@ static struct BurnRomInfo mslugxdgRomDesc[] = {
 STDROMPICKEXT(mslugxdg, mslugxdg, neogeo)
 STD_ROM_FN(mslugxdg)
 
-struct BurnDriver BurnDrvmslugxdg = {
+struct BurnDriver BurnDrvMslugxdg = {
 	"mslugxdg", "mslugx", "neogeo", NULL, "2023",
 	"Metal Slug X (Multifunction, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -21940,12 +22054,12 @@ struct BurnDriver BurnDrvmslugxdg = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug X (Legendary Unlimited Fire, Hack) - 2024-12-02
+// Metal Slug X (Legendary Unlimited Fire, Hack) - 2025-02-13
 // Modified by ?
 
 static struct BurnRomInfo mslugxcqiRomDesc[] = {
-	{ "250-p1cqi.p1",	0x100000, 0x03bb5d5c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "250-p2cqi.ep1",	0x400000, 0x03fc0122, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "250-p1cqi.p1",	0x100000, 0xf1cd0db7, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2cqi.ep1",	0x400000, 0xab4cd88e, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },           //  2 Text layer tiles
 
@@ -21967,11 +22081,47 @@ STDROMPICKEXT(mslugxcqi, mslugxcqi, neogeo)
 STD_ROM_FN(mslugxcqi)
 
 struct BurnDriver BurnDrvMslugxcqi = {
-	"mslugxcqi", "mslugx", "neogeo", NULL, "2024",
+	"mslugxcqi", "mslugx", "neogeo", NULL, "2025",
 	"Metal Slug X (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslugxcqiRomInfo, mslugxcqiRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	mslugxscInit, NeoExit, NeoFrame, NeoRender, mslugxScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+// Metal Slug X (Soldier Version, Hack) - 2025-04-28
+// Modified by ?
+
+static struct BurnRomInfo mslugxsvhRomDesc[] = {
+	{ "250-p1svh.p1",	0x100000, 0x787403ef, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "250-p2svh.ep1",	0x800000, 0xbcb02121, 1 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "250-s1.s1",		0x020000, 0xfb6f441d, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "250-c1.c1",		0x800000, 0x09a52c6f, 3 | BRF_GRA },           //  3 Sprite data
+	{ "250-c2.c2",		0x800000, 0x31679821, 3 | BRF_GRA },           //  4
+	{ "250-c3.c3",		0x800000, 0xfd602019, 3 | BRF_GRA },           //  5
+	{ "250-c4.c4",		0x800000, 0x31354513, 3 | BRF_GRA },           //  6
+	{ "250-c5svh.c5",	0x800000, 0x882f41c7, 3 | BRF_GRA },           //  7
+	{ "250-c6svh.c6",	0x800000, 0x35b5bb3a, 3 | BRF_GRA },           //  8
+
+	{ "250-m1.m1",		0x020000, 0xfd42a842, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+
+	{ "250-v1.v1",		0x400000, 0xc79ede73, 5 | BRF_SND },           // 10 Sound data
+	{ "250-v2.v2",		0x400000, 0xea9aabe1, 5 | BRF_SND },           // 11
+	{ "250-v3.v3",		0x200000, 0x2ca65102, 5 | BRF_SND },           // 12
+};
+
+STDROMPICKEXT(mslugxsvh, mslugxsvh, neogeo)
+STD_ROM_FN(mslugxsvh)
+
+struct BurnDriver BurnDrvMslugxsvh = {
+	"mslugxsvh", "mslugx", "neogeo", NULL, "2025",
+	"Metal Slug X (Soldier Version, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
+	NULL, mslugxsvhRomInfo, mslugxsvhRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	mslugxscInit, NeoExit, NeoFrame, NeoRender, mslugxScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -22004,7 +22154,7 @@ static struct BurnRomInfo mslug3gwRomDesc[] = {
 STDROMPICKEXT(mslug3gw, mslug3gw, neogeo)
 STD_ROM_FN(mslug3gw)
 
-struct BurnDriver BurnDrvmslug3gw = {
+struct BurnDriver BurnDrvMslug3gw = {
 	"mslug3gw", "mslug3", "neogeo", NULL, "2016",
 	"Metal Slug 3 (Onimusha Samanosuke, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22041,7 +22191,7 @@ static struct BurnRomInfo mslug3seRomDesc[] = {
 STDROMPICKEXT(mslug3se, mslug3se, neogeo)
 STD_ROM_FN(mslug3se)
 
-struct BurnDriver BurnDrvmslug3se = {
+struct BurnDriver BurnDrvMslug3se = {
 	"mslug3se", "mslug3", "neogeo", NULL, "2016",
 	"Metal Slug 3 (SE, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22078,7 +22228,7 @@ static struct BurnRomInfo mslug3zhRomDesc[] = {
 STDROMPICKEXT(mslug3zh, mslug3zh, neogeo)
 STD_ROM_FN(mslug3zh)
 
-struct BurnDriver BurnDrvmslug3zh = {
+struct BurnDriver BurnDrvMslug3zh = {
 	"mslug3zh", "mslug3", "neogeo", NULL, "2017",
 	"Metal Slug 3 (Vehicle Summon, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22115,7 +22265,7 @@ static struct BurnRomInfo mslug3sdRomDesc[] = {
 STDROMPICKEXT(mslug3sd, mslug3sd, neogeo)
 STD_ROM_FN(mslug3sd)
 
-struct BurnDriver BurnDrvmslug3sd = {
+struct BurnDriver BurnDrvMslug3sd = {
 	"mslug3sd", "mslug3", "neogeo", NULL, "2017",
 	"Metal Slug 3 (Shop Edition, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22155,7 +22305,7 @@ static struct BurnRomInfo mslug31v2RomDesc[] = {
 STDROMPICKEXT(mslug31v2, mslug31v2, neogeo)
 STD_ROM_FN(mslug31v2)
 
-struct BurnDriver BurnDrvmslug31v2 = {
+struct BurnDriver BurnDrvMslug31v2 = {
 	"mslug31v2", "mslug3", "neogeo", NULL, "2019",
 	"Metal Slug 3 (1v2 Mode, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22165,12 +22315,12 @@ struct BurnDriver BurnDrvmslug31v2 = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legendary, Hack) - 2024-06-12
+// Metal Slug 3 (Legendary, Hack) - 2024-12-03
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug3cqRomDesc[] = {
-	{ "256-ph1cq.p1",    0x100000, 0x6f84cdee, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "256-ph2cq.sp2",   0x400000, 0x14b0a9cf, 1 | BRF_ESS | BRF_PRG }, //  1 
+	{ "256-ph1cq.p1",    0x100000, 0x84241993, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "256-ph2cq.sp2",   0x400000, 0x09607601, 1 | BRF_ESS | BRF_PRG }, //  1 
 
 	{ "256-c1d.c1",      0x800000, 0x3540398c, 3 | BRF_GRA },           //  2 Sprite data
 	{ "256-c2d.c2",      0x800000, 0xbdd220f0, 3 | BRF_GRA },           //  3
@@ -22192,7 +22342,7 @@ static struct BurnRomInfo mslug3cqRomDesc[] = {
 STDROMPICKEXT(mslug3cq, mslug3cq, neogeo)
 STD_ROM_FN(mslug3cq)
 
-struct BurnDriver BurnDrvmslug3cq = {
+struct BurnDriver BurnDrvMslug3cq = {
 	"mslug3cq", "mslug3", "neogeo", NULL, "2024",
 	"Metal Slug 3 (Legendary, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22239,12 +22389,12 @@ struct BurnDriver BurnDrvMslug3cqi = {
 	0x1000, 304, 224, 4, 3
 };
 
-// Metal Slug 3 (Legend Tower Defense, Hack) - 2024-12-03
+// Metal Slug 3 (Legend Tower Defense, Hack) - 2024-12-29
 // Modified by ?
 
 static struct BurnRomInfo mslug3cqtfbRomDesc[] = {
-	{ "256-ph1cqt.p1",	0x100000, 0x4ad95272, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
-	{ "256-ph2cqt.sp2",	0x800000, 0x7a34c4e5, 1 | BRF_ESS | BRF_PRG },	//  1 
+	{ "256-ph1cqt.p1",	0x100000, 0x9a40066b, 1 | BRF_ESS | BRF_PRG },	//  0 68K code
+	{ "256-ph2cqt.sp2",	0x800000, 0xfcf952e5, 1 | BRF_ESS | BRF_PRG },	//  1 
 
 	{ "256-c1d.c1",		0x800000, 0x3540398c, 3 | BRF_GRA },			//  2 Sprite data
 	{ "256-c2d.c2",		0x800000, 0xbdd220f0, 3 | BRF_GRA },			//  3
@@ -22252,8 +22402,8 @@ static struct BurnRomInfo mslug3cqtfbRomDesc[] = {
 	{ "256-c4d.c4",		0x800000, 0x1463add6, 3 | BRF_GRA },			//  5
 	{ "256-c5d.c5",		0x800000, 0x48ca7f28, 3 | BRF_GRA },			//  6
 	{ "256-c6d.c6",		0x800000, 0x806eb36f, 3 | BRF_GRA },			//  7
-	{ "256-c7cqt.c7",	0x800000, 0x56f71abe, 3 | BRF_GRA },			//  8
-	{ "256-c8cqt.c8",	0x800000, 0xa2f280f6, 3 | BRF_GRA },			//  9
+	{ "256-c7cqt.c7",	0x800000, 0xac5d0a7e, 3 | BRF_GRA },			//  8
+	{ "256-c8cqt.c8",	0x800000, 0xe0018022, 3 | BRF_GRA },			//  9
 
 	{ "256-m1.m1",		0x080000, 0xeaeec116, 4 | BRF_ESS | BRF_PRG },	// 10 Z80 code
 
@@ -22341,7 +22491,7 @@ static struct BurnRomInfo mslug4ammorRomDesc[] = {
 STDROMPICKEXT(mslug4ammor, mslug4ammor, neogeo)
 STD_ROM_FN(mslug4ammor)
 
-struct BurnDriver BurnDrvmslug4ammor = {
+struct BurnDriver BurnDrvMslug4ammor = {
 	"mslug4ammor", "mslug4", "neogeo", NULL, "2023",
 	"Metal Slug 4 (Random Ammunition, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22378,7 +22528,7 @@ static struct BurnRomInfo mslug4lwqRomDesc[] = {
 STDROMPICKEXT(mslug4lwq, mslug4lwq, neogeo)
 STD_ROM_FN(mslug4lwq)
 
-struct BurnDriver BurnDrvmslug4lwq = {
+struct BurnDriver BurnDrvMslug4lwq = {
 	"mslug4lwq", "mslug4", "neogeo", NULL, "2023",
 	"Metal Slug 4 (LW Armor Disabled, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22388,12 +22538,12 @@ struct BurnDriver BurnDrvmslug4lwq = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2024-12-02
+// Metal Slug 4 (Legendary Unlimited Fire, Hack) - 2025-02-13
 // Modified by ?
 
 static struct BurnRomInfo mslug4zjhlRomDesc[] = {
-	{ "263-p1zjh.p1",	0x100000, 0x2403ce15, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2zjh.sp2",	0x800000, 0xe0ed3fe0, 1 | BRF_ESS | BRF_PRG },  //  1
+	{ "263-p1zjh.p1",	0x100000, 0x7ff2f18e, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "263-p2zjh.sp2",	0x800000, 0x22abf687, 1 | BRF_ESS | BRF_PRG },  //  1
 	
 	{ "263-s1d.s1",		0x020000, 0xa9446774, 2 | BRF_GRA },            //  2 Text layer tiles
 
@@ -22404,17 +22554,17 @@ static struct BurnRomInfo mslug4zjhlRomDesc[] = {
 	{ "263-c5zjh.c5",	0x800000, 0x3b0347a0, 3 | BRF_GRA },            //  7
 	{ "263-c6zjh.c6",	0x800000, 0xe95f5ef5, 3 | BRF_GRA },            //  8
 
-	{ "263-m1zjh.m1",	0x020000, 0x2c722ea4, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
+	{ "263-m1zjh.m1",	0x020000, 0x98e75e61, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
 
-	{ "263-v1zjh.v1",	0x800000, 0xe06d7658, 5 | BRF_SND },            // 10 Sound data
-	{ "263-v2zjh.v2",	0x800000, 0xf74df238, 5 | BRF_SND },            // 11
+	{ "263-v1zjh.v1",	0x800000, 0x3a8ff8f1, 5 | BRF_SND },            // 10 Sound data
+	{ "263-v2zjh.v2",	0x800000, 0xfe4f910c, 5 | BRF_SND },            // 11
 };
 
 STDROMPICKEXT(mslug4zjhl, mslug4zjhl, neogeo)
 STD_ROM_FN(mslug4zjhl)
 
 struct BurnDriver BurnDrvMslug4zjhl = {
-	"mslug4zjhl", "mslug4", "neogeo", NULL, "2024",
+	"mslug4zjhl", "mslug4", "neogeo", NULL, "2025",
 	"Metal Slug 4 (Legendary Unlimited Fire, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
@@ -22450,7 +22600,7 @@ static struct BurnRomInfo mslug4qRomDesc[] = {
 STDROMPICKEXT(mslug4q, mslug4q, neogeo)
 STD_ROM_FN(mslug4q)
 
-struct BurnDriver BurnDrvmslug4q = {
+struct BurnDriver BurnDrvMslug4q = {
 	"mslug4q", "mslug4", "neogeo", NULL, "2022",
 	"Metal Slug 4 (The Longest Battle, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22486,7 +22636,7 @@ static struct BurnRomInfo mslug41v2RomDesc[] = {
 STDROMPICKEXT(mslug41v2, mslug41v2, neogeo)
 STD_ROM_FN(mslug41v2)
 
-struct BurnDriver BurnDrvmslug41v2 = {
+struct BurnDriver BurnDrvMslug41v2 = {
 	"mslug41v2", "mslug4", "neogeo", NULL, "2019",
 	"Metal Slug 4 (1v2 Mode, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22525,7 +22675,7 @@ static struct BurnRomInfo mslug5dbjRomDesc[] = {
 STDROMPICKEXT(mslug5dbj, mslug5dbj, neogeo)
 STD_ROM_FN(mslug5dbj)
 
-struct BurnDriver BurnDrvmslug5dbj = {
+struct BurnDriver BurnDrvMslug5dbj = {
 	"mslug5dbj", "mslug5", "neogeo", NULL, "2020",
 	"Metal Slug 5 (Enemy Enhance, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22563,7 +22713,7 @@ static struct BurnRomInfo mslug5esRomDesc[] = {
 STDROMPICKEXT(mslug5es, mslug5es, neogeo)
 STD_ROM_FN(mslug5es)
 
-struct BurnDriver BurnDrvmslug5es = {
+struct BurnDriver BurnDrvMslug5es = {
 	"mslug5es", "mslug5", "neogeo", NULL, "2023",
 	"Metal Slug 5 (Double Enemy, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22601,7 +22751,7 @@ static struct BurnRomInfo mslug5sgRomDesc[] = {
 STDROMPICKEXT(mslug5sg, mslug5sg, neogeo)
 STD_ROM_FN(mslug5sg)
 
-struct BurnDriver BurnDrvmslug5sg = {
+struct BurnDriver BurnDrvMslug5sg = {
 	"mslug5sg", "mslug5", "neogeo", NULL, "2024",
 	"Metal Slug 5 (Stone Turtle, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22639,7 +22789,7 @@ static struct BurnRomInfo mslug5zhRomDesc[] = {
 STDROMPICKEXT(mslug5zh, mslug5zh, neogeo)
 STD_ROM_FN(mslug5zh)
 
-struct BurnDriver BurnDrvmslug5zh = {
+struct BurnDriver BurnDrvMslug5zh = {
 	"mslug5zh", "mslug5", "neogeo", NULL, "2018",
 	"Metal Slug 5 (Vehicle Summon, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22677,7 +22827,7 @@ static struct BurnRomInfo mslug51v2RomDesc[] = {
 STDROMPICKEXT(mslug51v2, mslug51v2, neogeo)
 STD_ROM_FN(mslug51v2)
 
-struct BurnDriver BurnDrvmslug51v2 = {
+struct BurnDriver BurnDrvMslug51v2 = {
 	"mslug51v2", "mslug5", "neogeo", NULL, "2018",
 	"Metal Slug 5 (1v2 Mode, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22715,7 +22865,7 @@ static struct BurnRomInfo mslug5extRomDesc[] = {
 STDROMPICKEXT(mslug5ext, mslug5ext, neogeo)
 STD_ROM_FN(mslug5ext)
 
-struct BurnDriver BurnDrvmslug5ext = {
+struct BurnDriver BurnDrvMslug5ext = {
 	"mslug5ext", "mslug5", "neogeo", NULL, "2018",
 	"Metal Slug 5 (Extend Ver, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22754,7 +22904,7 @@ static struct BurnRomInfo mslug5fRomDesc[] = {
 STDROMPICKEXT(mslug5f, mslug5f, neogeo)
 STD_ROM_FN(mslug5f)
 
-struct BurnDriver BurnDrvmslug5f = {
+struct BurnDriver BurnDrvMslug5f = {
 	"mslug5f", "mslug5", "neogeo", NULL, "2016",
 	"Metal Slug 5 (Fierce Battle, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22792,7 +22942,7 @@ static struct BurnRomInfo mslug5bossRomDesc[] = {
 STDROMPICKEXT(mslug5boss, mslug5boss, neogeo)
 STD_ROM_FN(mslug5boss)
 
-struct BurnDriver BurnDrvmslug5boss = {
+struct BurnDriver BurnDrvMslug5boss = {
 	"mslug5boss", "mslug5", "neogeo", NULL, "2024",
 	"Metal Slug 5 (Boss Battle, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22830,7 +22980,7 @@ static struct BurnRomInfo mslug5ctRomDesc[] = {
 STDROMPICKEXT(mslug5ct, mslug5ct, neogeo)
 STD_ROM_FN(mslug5ct)
 
-struct BurnDriver BurnDrvmslug5ct = {
+struct BurnDriver BurnDrvMslug5ct = {
 	"mslug5ct", "mslug5", "neogeo", NULL, "2023",
 	"Metal Slug 5 (Survival, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22868,7 +23018,7 @@ static struct BurnRomInfo mslug5anRomDesc[] = {
 STDROMPICKEXT(mslug5an, mslug5an, neogeo)
 STD_ROM_FN(mslug5an)
 
-struct BurnDriver BurnDrvmslug5an = {
+struct BurnDriver BurnDrvMslug5an = {
 	"mslug5an", "mslug5", "neogeo", NULL, "2024",
 	"Metal Slug 5 (20th Anniversary, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
@@ -22878,11 +23028,11 @@ struct BurnDriver BurnDrvmslug5an = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (The Ultimate Legend, Hack) - 2024-12-03
+// Metal Slug 5 (The Ultimate Legend, Hack) - 2025-04-03, P1 bug fix
 // Modified by 合金弹头爱克斯
 
 static struct BurnRomInfo mslug5cqRomDesc[] = {
-	{ "268-p1cq.p1",	0xa00000, 0xa90e4f49, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
+	{ "268-p1cq.p1",	0xa00000, 0x95787416, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
 
 	{ "268-s1d.s1",		0x020000, 0x64952683, 2 | BRF_GRA },            //  1 Text layer tiles
 
@@ -22890,10 +23040,10 @@ static struct BurnRomInfo mslug5cqRomDesc[] = {
 	{ "268-c2d.c2",		0x800000, 0x89b21d4c, 3 | BRF_GRA },            //  3
 	{ "268-c3d.c3",		0x800000, 0x3cda13a0, 3 | BRF_GRA },            //  4
 	{ "268-c4d.c4",		0x800000, 0x9c00160d, 3 | BRF_GRA },            //  5
-	{ "268-c5d.c5",		0x800000, 0x38754256, 3 | BRF_GRA },            //  6
-	{ "268-c6d.c6",		0x800000, 0x59d33e9c, 3 | BRF_GRA },            //  7
-	{ "268-c7cq.c7",	0x800000, 0xd902d555, 3 | BRF_GRA },            //  8
-	{ "268-c8cq.c8",	0x800000, 0x59b7dc26, 3 | BRF_GRA },            //  9
+	{ "268-c5cq.c5",	0x800000, 0x46c761bd, 3 | BRF_GRA },            //  6
+	{ "268-c6cq.c6",	0x800000, 0x93bd5717, 3 | BRF_GRA },            //  7
+	{ "268-c7cq.c7",	0x800000, 0x1e0f83aa, 3 | BRF_GRA },            //  8
+	{ "268-c8cq.c8",	0x800000, 0xd36812db, 3 | BRF_GRA },            //  9
 
 	{ "268-m1d.m1",		0x080000, 0x39f3cbba, 4 | BRF_ESS | BRF_PRG },  // 10 Z80 code
 
@@ -22904,8 +23054,8 @@ static struct BurnRomInfo mslug5cqRomDesc[] = {
 STDROMPICKEXT(mslug5cq, mslug5cq, neogeo)
 STD_ROM_FN(mslug5cq)
 
-struct BurnDriver BurnDrvmslug5cq = {
-	"mslug5cq", "mslug5", "neogeo", NULL, "2024",
+struct BurnDriver BurnDrvMslug5cq = {
+	"mslug5cq", "mslug5", "neogeo", NULL, "2025",
 	"Metal Slug 5 (The Ultimate Legend, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -22840,7 +22840,7 @@ struct BurnDriver BurnDrvmslug5ct = {
 	0x1000,	304, 224, 4, 3
 };
 
-// Metal Slug 5 (Extremely Simplified, Hack) - 2024-10-10
+// Metal Slug 5 (20th Anniversary, Hack) - 2024-10-10
 // Modified by 明天再努力吧
 
 static struct BurnRomInfo mslug5anRomDesc[] = {
@@ -22869,8 +22869,8 @@ STDROMPICKEXT(mslug5an, mslug5an, neogeo)
 STD_ROM_FN(mslug5an)
 
 struct BurnDriver BurnDrvmslug5an = {
-	"mslug5an", "mslug5", "neogeo", NULL, "2022",
-	"Metal Slug 5 (Extremely Simplified, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"mslug5an", "mslug5", "neogeo", NULL, "2024",
+	"Metal Slug 5 (20th Anniversary, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug5anRomInfo, mslug5anRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,

--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -266,6 +266,8 @@ UINT8 *NeoSpriteRAM, *NeoTextRAM;
 UINT8 *Neo68KBIOS, *NeoZ80BIOS;
 static UINT8 *Neo68KRAM, *NeoZ80RAM, *NeoNVRAM, *NeoNVRAM2, *NeoMemoryCard;
 
+static UINT32 nNeo68KRAMLen = 0x010000;
+
 static UINT32 nSpriteSize[MAX_SLOT] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 static UINT32 nCodeSize[MAX_SLOT] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
@@ -361,7 +363,7 @@ static INT32 RAMIndex()
 	NeoGraphicsRAM		= Next; Next += 0x020000;		// Graphics controller RAM (2 64KB banks)
 
 	if (nNeoSystemType & NEO_SYS_CART) {
-		Neo68KRAM		= Next; Next += 0x010000;		// 68K work RAM
+		Neo68KRAM		= Next; Next += nNeo68KRAMLen;		// 68K work RAM
 		NeoZ80RAM		= Next; Next += 0x000800;		// Z80 RAM
 
 		NeoNVRAM		= Next; Next += 0x010000;		// Battery backed SRAM
@@ -1379,7 +1381,7 @@ INT32 NeoScan(INT32 nAction, INT32* pnMin)
 
 		if (nNeoSystemType & NEO_SYS_CART) {
 			ba.Data		= Neo68KRAM;
-			ba.nLen		= 0x00010000;
+			ba.nLen		= nNeo68KRAMLen;
 			ba.nAddress = 0;
 			ba.szName	= "68K RAM";
 			BurnAcb(&ba);
@@ -3974,10 +3976,13 @@ static INT32 NeoInitCommon()
 
 		if (nNeoSystemType & NEO_SYS_CART) {
 
-			for (INT32 a = 0x100000; a < 0x200000; a += 0x010000) {
-				SekMapMemory(Neo68KRAM, a, a + 0xFFFF, MAP_RAM);				// 68K RAM
+			if (nNeo68KRAMHack > 0) {
+				SekMapMemory(Neo68KRAM, 0x100000, 0x1FFFFF, MAP_RAM);		// 68K RAM
+			} else {
+				for (INT32 a = 0x100000; a < 0x200000; a += 0x010000) {
+					SekMapMemory(Neo68KRAM, a, a + 0xFFFF, MAP_RAM);		// 68K RAM
 			}
-
+		}
 			if (!(nNeoSystemType & NEO_SYS_PCB)) {
 //				for (INT32 a = 0xC00000; a < 0xD00000; a += 0x020000) {
 //					SekMapMemory(Neo68KBIOS, a, a + 0x01FFFF, MAP_ROM);		// MVS/AES BIOS ROM
@@ -4205,6 +4210,8 @@ static bool recursing = false;
 
 INT32 NeoInit()
 {
+	nNeo68KRAMLen = ((nNeo68KRAMHack > 0) || bDoIpsPatch) ? 0x100000 : 0x010000;
+	
 	if (recursing) {
 		if (LoadRoms()) {
 			return 1;
@@ -4485,6 +4492,7 @@ INT32 NeoExit()
 	vlinermode = 0;
 
 	nNeoSystemType = 0;
+	nNeo68KRAMLen = 0;
 
 	return 0;
 }
@@ -4605,7 +4613,7 @@ INT32 NeoFrame()
 
 	if (NeoReset) {							   						// Reset machine
 		if (nNeoSystemType & NEO_SYS_CART) {
-			memset(Neo68KRAM, 0, 0x010000);
+			memset(Neo68KRAM, 0, nNeo68KRAMLen);
 		}
 		if (nNeoSystemType & NEO_SYS_CD) {
 			memset(Neo68KROM[0], 0, nCodeSize[0]);

--- a/src/burn/drv/neogeo/neogeo.h
+++ b/src/burn/drv/neogeo/neogeo.h
@@ -77,6 +77,7 @@ extern UINT8* Neo68KFix[MAX_SLOT];
 
 extern UINT32 nNeo68KROMBank;
 
+extern UINT8 nNeo68KRAMHack;
 extern UINT8 *NeoSpriteRAM, *NeoTextRAM;
 
 extern bool bNeoEnableGraphics;

--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -22088,10 +22088,10 @@ STD_ROM_PICK(nes_kinni)
 STD_ROM_FN(nes_kinni)
 
 struct BurnDriver BurnDrvnes_kinni = {
-	"nes_kinni", NULL, NULL, NULL, "1985",
+	"nes_kinni", "nes_muscle", NULL, NULL, "1985",
 	"Kinnikuman - Muscle Tag Match (Japan)\0", NULL, "Bandai", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING, 2, HARDWARE_NES, GBF_MISC, 0,
+	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_NES, GBF_MISC, 0,
 	NESGetZipName, nes_kinniRomInfo, nes_kinniRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
 	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT

--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -32291,6 +32291,28 @@ struct BurnDriver BurnDrvnes_zunousengal = {
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
 
+// ----------
+// Extra Roms
+// ----------
+
+// Hoops (USA)
+static struct BurnRomInfo nes_hoopsRomDesc[] = {
+	{ "Hoops (USA)(1989)(Jaleco).nes",          262160, 0x08f89bb0, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(nes_hoops)
+STD_ROM_FN(nes_hoops)
+
+struct BurnDriver BurnDrvnes_hoops = {
+	"nes_hoops", NULL, NULL, NULL, "1989",
+	"Hoops (USA)\0", NULL, "Jaleco", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 2, HARDWARE_NES, GBF_SPORTSMISC, 0,
+	NESGetZipName, nes_hoopsRomInfo, nes_hoopsRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
+	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
+	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
+};
+
 // Kart Fighter (Unl)
 
 static struct BurnRomInfo nes_kartfighterRomDesc[] = {
@@ -32306,6 +32328,42 @@ struct BurnDriver BurnDrvnes_kartfighter = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_NES, GBF_VSFIGHT, 0,
 	NESGetZipName, nes_kartfighterRomInfo, nes_kartfighterRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
+	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
+	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
+};
+
+//Little League Baseball - Championship Series (USA)
+static struct BurnRomInfo nes_littleleagueRomDesc[] = {
+	{ "Little League Baseball - Championship Series (1990)(SNK)(USA).nes",          262160, 0x7905ae67, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(nes_littleleague)
+STD_ROM_FN(nes_littleleague)
+
+struct BurnDriver BurnDrvnes_littleleague = {
+	"nes_littleleague", NULL, NULL, NULL, "1990",
+	"Little League Baseball - Championship Series (USA)\0", NULL, "SNK", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 2, HARDWARE_NES, GBF_SPORTSMISC, 0,
+	NESGetZipName, nes_littleleagueRomInfo, nes_littleleagueRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
+	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
+	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
+};
+
+// Moero!! Junior Basket: Two on Two (Japan)
+static struct BurnRomInfo nes_moerojrbasRomDesc[] = {
+	{ "Moero!! Junior Basket - Two on Two (Japan)(1988)(Jaleco).nes",          262160, 0x6ed22c25, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(nes_moerojrbas)
+STD_ROM_FN(nes_moerojrbas)
+
+struct BurnDriver BurnDrvnes_moerojrbas = {
+	"nes_moerojrbas", "nes_hoops", NULL, NULL, "1988",
+	"Moero!! Junior Basket: Two on Two (Japan)\0", NULL, "Jaleco", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_NES, GBF_SPORTSMISC, 0,
+	NESGetZipName, nes_moerojrbasRomInfo, nes_moerojrbasRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
 	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
@@ -32346,9 +32404,9 @@ struct BurnDriver BurnDrvnes_hackmatch = {
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
 
-// Pacman CE
+// Pac-Man Championship Edition (World)
 static struct BurnRomInfo nes_pacmanceRomDesc[] = {
-	{ "pacman-ce (2020).nes",          262160, 0xb86c09af, BRF_ESS | BRF_PRG },
+	{ "Pac-Man CE (2020)(Namco - BNEI).nes",          262160, 0xb86c09af, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_pacmance)
@@ -32356,7 +32414,7 @@ STD_ROM_FN(nes_pacmance)
 
 struct BurnDriver BurnDrvnes_pacmance = {
 	"nes_pacmance", NULL, NULL, NULL, "2020",
-	"Pac-Man Championship Edition\0", NULL, "Namco - BNEI", "Miscellaneous",
+	"Pac-Man Championship Edition (World)\0", NULL, "Namco - BNEI", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 2, HARDWARE_NES, GBF_MAZE | GBF_ACTION, 0,
 	NESGetZipName, nes_pacmanceRomInfo, nes_pacmanceRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,

--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -19327,7 +19327,7 @@ struct BurnDriver BurnDrvnes_ghostbustersii = {
 };
 
 static struct BurnRomInfo nes_ghostsngoblinsRomDesc[] = {
-	{ "Ghosts'n Goblins (USA).nes",          131088, 0x983dd1de, BRF_ESS | BRF_PRG },
+	{ "Ghosts'n Goblins (USA)(1986)(Capcom).nes",          131088, 0x87ed54aa, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_ghostsngoblins)

--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -32366,7 +32366,7 @@ struct BurnDriver BurnDrvnes_pacmance = {
 
 // Mischief Castle (HB)
 static struct BurnRomInfo nes_miscastleRomDesc[] = {
-	{ "Mischief Castle (2024)(kn56k).nes",          524304, 0x73e3120b, BRF_ESS | BRF_PRG },
+	{ "Mischief Castle (2024)(kn56k).nes",          524304, 0x39fc03f4, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_miscastle)

--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -24732,17 +24732,18 @@ struct BurnDriver BurnDrvnes_nekkestrbas = {
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
 
-// Nekketsu! Street Basket: Ganbare Dunk Heroes (T-Eng)
+// Nekketsu! Street Basket - Go for it, Dunk Heroes (Hack, English v1.2)
+// https://www.romhacking.net/translations/1548/
 static struct BurnRomInfo nes_nekkestrbasenRomDesc[] = {
-	{ "Nekketsu! Street Basket - Ganbare Dunk Heroes (T-Eng).nes",          262160, 0xa4680ca5, BRF_ESS | BRF_PRG },
+	{ "Nekketsu! Street Basket - Go for it, Dunk Heroes T-Eng v1.2 (2013)(Farid).nes",          262160, 0xa4680ca5, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_nekkestrbasen)
 STD_ROM_FN(nes_nekkestrbasen)
 
 struct BurnDriver BurnDrvnes_nekkestrbasen = {
-	"nes_nekkestrbasen", "nes_nekkestrbas", NULL, NULL, "2010",
-	"Nekketsu! Street Basket - Ganbare Dunk Heroes (T-Eng)\0", NULL, "Farid", "Miscellaneous",
+	"nes_nekkestrbasen", "nes_nekkestrbas", NULL, NULL, "2013",
+	"Nekketsu! Street Basket - Go for it, Dunk Heroes (Hack, English v1.2)\0", NULL, "hack (Farid)", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_NES, GBF_MISC, 0,
 	NESGetZipName, nes_nekkestrbasenRomInfo, nes_nekkestrbasenRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
@@ -32363,6 +32364,24 @@ struct BurnDriver BurnDrvnes_pacmance = {
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
 
+// Mischief Castle (HB)
+static struct BurnRomInfo nes_miscastleRomDesc[] = {
+	{ "Mischief Castle (2024)(kn56k).nes",          524304, 0x73e3120b, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(nes_miscastle)
+STD_ROM_FN(nes_miscastle)
+
+struct BurnDriver BurnDrvnes_miscastle = {
+	"nes_miscastle", NULL, NULL, NULL, "2024",
+	"Mischief Castle (HB)\0", NULL, "kn56k", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_NES, GBF_PLATFORM, 0,
+	NESGetZipName, nes_miscastleRomInfo, nes_miscastleRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
+	NES4ScoreInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
+	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
+};
+
 static struct BurnRomInfo nes_pentablocatRomDesc[] = {
 	{ "Pentablocat (2023)(Pineberry fox).nes",          24592, 0x27a14751, BRF_ESS | BRF_PRG },
 };
@@ -32433,6 +32452,24 @@ struct BurnDriver BurnDrvnes_contrafntg = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_NES, GBF_RUNGUN | GBF_PLATFORM, 0,
 	NESGetZipName, nes_contrafntgRomInfo, nes_contrafntgRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
+	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
+	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
+};
+
+// Zed and Zee (HB)
+static struct BurnRomInfo nes_zednzeeRomDesc[] = {
+	{ "Zed and Zee (2024)(Tengen Games).nes",          524304, 0x506fb3fb, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(nes_zednzee)
+STD_ROM_FN(nes_zednzee)
+
+struct BurnDriver BurnDrvnes_zednzee = {
+	"nes_zednzee", NULL, NULL, NULL, "2024",
+	"Zed and Zee (HB)\0", NULL, "Tengen Games", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_NES, GBF_PLATFORM, 0,
+	NESGetZipName, nes_zednzeeRomInfo, nes_zednzeeRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
 	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };

--- a/src/burn/drv/pst90s/d_metro.cpp
+++ b/src/burn/drv/pst90s/d_metro.cpp
@@ -4764,7 +4764,7 @@ struct BurnDriver BurnDrvPoitto = {
 // Poitto! (revision C)
 
 static struct BurnRomInfo poittocRomDesc[] = {
-	{ "pt-jc05.20e",		0x020000, 0x6b1be034, 1 | BRF_PRG | BRF_ESS }, //  0 68k Code
+	{ "pt-jc05.20e",		0x020000, 0x96681051, 1 | BRF_PRG | BRF_ESS }, //  0 68k Code
 	{ "pt-jc06.20c",		0x020000, 0x00000000, 1 | BRF_PRG | BRF_ESS | BRF_NODUMP }, //  1
 
 	{ "pt-jc08.3i",			0x020000, 0xf32d386a, 2 | BRF_PRG | BRF_ESS }, //  2 uPD7810 Code


### PR DESCRIPTION
15/06/2025

d_cps1:
updated sf2mix

d_cps2:
added: mshvsfcph, sf2prime
correct inputList in cybotsbh

d_deco32:
added: tattasso
updated: tattass, tattassa

d_megadrive
added: md_bssf2gq, md_doroppu, md_fatfuryone, md_ffightmd, md_knnsf, md_puzzulswap, md_rbffgenlt, md_s3compes, md_shaolincarcara
updated: md_cavestory, md_punisor, md_umk3osc

d_neogeo
added: bpanicdx, flapchck, kof96pls, kof97ratio, kof97sp, kof97eb, kof99sk, kof2ksp, kf2k1ult, kf2k2mix, kof2002t, mslug3cqzt, mslug4zjhl, mslug5ammor, mslugxxb, xenocrisis
updated: gowcaiet, kof94te, kof94tea,  kof96a, lastbladsp, mslugdqy, mslugfc2, mslugdyf2 (mslugdyf1), mslugxcqi, mslug3cqi, mslug3cq, mslug3cqtfb, mslug3g, mslug5cq, samsho2pe

d_nes
added: nes_hoops, nes_littleleague, nes_moerojrbas, nes_miscastle, nes_zednzee
updated: nes_ghostsngoblins